### PR TITLE
Fix imports and import order

### DIFF
--- a/rainsd/engine.go
+++ b/rainsd/engine.go
@@ -1,9 +1,9 @@
 package rainsd
 
 import (
-	"rains/rainslib"
-
 	log "github.com/inconshreveable/log15"
+
+	"github.com/netsec-ethz/rains/rainslib"
 )
 
 //assertionCache contains a set of valid assertions where some of them might be expired.

--- a/rainsd/inbox.go
+++ b/rainsd/inbox.go
@@ -2,10 +2,11 @@ package rainsd
 
 import (
 	"fmt"
-	"rains/rainslib"
-	"rains/utils/parser"
 
 	log "github.com/inconshreveable/log15"
+
+	"github.com/netsec-ethz/rains/rainslib"
+	"github.com/netsec-ethz/rains/utils/parser"
 )
 
 //incoming messages are buffered in one of these channels until they get processed by a worker go routine

--- a/rainsd/notification.go
+++ b/rainsd/notification.go
@@ -1,9 +1,9 @@
 package rainsd
 
 import (
-	"rains/rainslib"
-
 	log "github.com/inconshreveable/log15"
+
+	"github.com/netsec-ethz/rains/rainslib"
 )
 
 //notify handles incoming notification messages

--- a/rainsd/serverInfo.go
+++ b/rainsd/serverInfo.go
@@ -3,10 +3,11 @@ package rainsd
 import (
 	"crypto/x509"
 	"net"
-	"rains/rainslib"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/netsec-ethz/rains/rainslib"
 )
 
 var serverConnInfo ConnInfo

--- a/rainsd/serverUtil.go
+++ b/rainsd/serverUtil.go
@@ -9,10 +9,11 @@ import (
 	"errors"
 	"io/ioutil"
 	"math/big"
-	"rains/rainslib"
 
 	log "github.com/inconshreveable/log15"
 	"golang.org/x/crypto/ed25519"
+
+	"github.com/netsec-ethz/rains/rainslib"
 )
 
 const (

--- a/rainsd/verify.go
+++ b/rainsd/verify.go
@@ -3,13 +3,14 @@ package rainsd
 import (
 	"fmt"
 	"math/rand"
-	"rains/rainslib"
 	"strconv"
 	"sync"
 	"time"
 
 	log "github.com/inconshreveable/log15"
 	"golang.org/x/crypto/ed25519"
+
+	"github.com/netsec-ethz/rains/rainslib"
 )
 
 //zoneKeyCache contains a set of zone public keys

--- a/rainsdig/rainsdig.go
+++ b/rainsdig/rainsdig.go
@@ -8,10 +8,11 @@ import (
 	"io"
 	"net"
 	"os"
-	"rains/rainslib"
-	"rains/utils/parser"
 	"strconv"
 	"time"
+
+	"github.com/netsec-ethz/rains/rainslib"
+	"github.com/netsec-ethz/rains/utils/parser"
 )
 
 //TODO add default values to description

--- a/server/rainsServer.go
+++ b/server/rainsServer.go
@@ -1,6 +1,6 @@
 package main
 
-import "rains/rainsd"
+import "github.com/netsec-ethz/rains/rainsd"
 
 //This package initializes and starts the server
 

--- a/utils/parser/rainsMsgParser.go
+++ b/utils/parser/rainsMsgParser.go
@@ -3,11 +3,12 @@ package parser
 import (
 	"errors"
 	"fmt"
-	"rains/rainslib"
 	"strconv"
 	"strings"
 
 	log "github.com/inconshreveable/log15"
+
+	"github.com/netsec-ethz/rains/rainslib"
 )
 
 //RainsMsgParser contains methods to convert rainsMessages as a byte slice to an internal representation and vice versa


### PR DESCRIPTION
We should use absolute imports for our own stuff, the current one (e.g.
`"rains/rainslib"`) only work accidentally and are brittle. Also see
https://github.com/golang/go/issues/6147 for further reasons.

Also fixed the import order. We should use:

- standard library
- external dependencies
- internal (to our codebase) dependencies

These three should be section separated by empty lines and each section
sorted alphabetically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/rains/9)
<!-- Reviewable:end -->
