### PR TITLE
Recursive resolver library + integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BUILD_PATH=${GOPATH}/src/github.com/netsec-ethz/rains/build/
 
 LDFLAGS = -ldflags "-X main.buildinfo_hostname=${HOSTNAME} -X main.buildinfo_commit=${COMMIT} -X main.buildinfo_branch=${BRANCH}"
 
-all: clean rainsd rainspub rainsdig integration
+all: clean rainsd rainspub rainsdig integration resolve
 
 clean:
 	rm -rf ${BUILD_PATH}
@@ -32,4 +32,9 @@ integration:
 	go build ${LDFLAGS} -o integration github.com/netsec-ethz/rains/integration ;\
 	cd - >/dev/null
 
-.PHONY: clean rainsd rainspub rainsdig integration
+resolve:
+	cd ${BUILD_PATH}; \
+	go build ${LDFLAGS} -o resolve github.com/netsec-ethz/rains/resolve; \
+	cd - >/dev/null
+
+.PHONY: clean rainsd rainspub rainsdig integration resolve

--- a/example/server/main.go
+++ b/example/server/main.go
@@ -14,7 +14,7 @@ import (
 var (
 	debugAddr = flag.String("debug_addr", "[::1]:8080", "Address to listen on for debugging info server.")
 	config    = flag.String("config", "", "Path to configuration file.")
-	verbosity = flag.Int("verbosity", int(log.LvlInfo), "Verbosity of logging.")
+	verbosity = flag.Int("verbosity", int(log.LvlDebug), "Verbosity of logging.")
 
 	buildinfo_hostname string
 	buildinfo_commit   string

--- a/integration/configs/configs.go
+++ b/integration/configs/configs.go
@@ -12,7 +12,9 @@ var (
     :Z: . . [
         :S: [
             {{ range .L2TLDs }}
-                :A: {{ .TLD }} [ :deleg: ed25519 {{ .PubKey }} ]
+                :A: {{ .TLD }} [ :deleg: ed25519 {{ .PubKey }} :redir: ns.{{ .TLD }} ]
+                :A: ns.{{ .TLD }} [ :srv: ns1.{{ .TLD }} {{ .RedirPort }} 10 ]
+                :A: ns1.{{ .TLD }} [ :ip6: ::1 ]
             {{ end }}
         ]
     ]
@@ -144,8 +146,9 @@ func (rpc *RootPubConf) PubConfig() (string, error) {
 // the configuration for the root rainsPub instance.
 type RootPubParams struct {
 	L2TLDs []struct {
-		TLD    string
-		PubKey string
+		TLD       string
+		PubKey    string
+		RedirPort uint
 	}
 }
 

--- a/integration/utils/utils.go
+++ b/integration/utils/utils.go
@@ -46,7 +46,7 @@ func InstallBinaries(buildDir, tmpDir string) error {
 	if err := os.Mkdir(outBin, 0766); err != nil {
 		return fmt.Errorf("failed to create bin directory: %v", err)
 	}
-	requiredBins := []string{"rainsd", "rainspub", "rainsdig"}
+	requiredBins := []string{"rainsd", "rainspub", "resolve"}
 	for _, bin := range requiredBins {
 		if err := copyBinTmp(buildDir, bin, outBin); err != nil {
 			return fmt.Errorf("failed to copy binary to tmp dir %q: %v", outBin, err)

--- a/libresolve/lib.go
+++ b/libresolve/lib.go
@@ -197,6 +197,9 @@ func (r *Resolver) recursiveResolve(name, context string) (*rainslib.RainsMessag
 		concreteMap := make(map[string]string)
 		for _, section := range resp.Content {
 			switch section.(type) {
+			case *rainslib.ZoneSection:
+				// If we were given a whole zone it's because we asked for it or it's non-existance proof.
+				return resp, nil
 			case *rainslib.AssertionSection:
 				as := section.(*rainslib.AssertionSection)
 				sz := mergeSubjectZone(as.SubjectName, as.SubjectZone)

--- a/libresolve/lib.go
+++ b/libresolve/lib.go
@@ -209,7 +209,8 @@ func (r *Resolver) recursiveResolve(name, context string) (*rainslib.RainsMessag
 						deleg = obj.Value
 					}
 					if obj.Type == rainslib.OTServiceInfo {
-						serviceInfo = obj.Value.(*rainslib.ServiceInfo)
+						tmp := obj.Value.(rainslib.ServiceInfo)
+						serviceInfo = &tmp
 					}
 				}
 				glog.Infof("deleg was %v", deleg)
@@ -217,11 +218,11 @@ func (r *Resolver) recursiveResolve(name, context string) (*rainslib.RainsMessag
 					return nil, fmt.Errorf("Incomplete delegation chain, last response = %v", resp)
 				}
 				latestResolver = fmt.Sprintf("%s:%d", serviceInfo.Name, serviceInfo.Port)
+				glog.Infof("latestResolver updated to %v", latestResolver)
 			case *rainslib.ZoneSection:
 				// Negative case when a zone is returned to prove non-existance.
 				return resp, nil
 			}
 		}
-		return nil, fmt.Errorf("Didn't get delegation nor response")
 	}
 }

--- a/libresolve/lib.go
+++ b/libresolve/lib.go
@@ -1,0 +1,227 @@
+// Package libresolve implements a recursive and stub resolver for RAINS.
+package libresolve
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/netsec-ethz/rains/rainslib"
+	"github.com/netsec-ethz/rains/utils/protoParser"
+)
+
+type ResolutionMode int
+
+var (
+	defaultTimeout  = 10 * time.Second
+	defaultFailFast = true
+)
+
+const (
+	ResolutionModeRecursive ResolutionMode = iota
+	ResolutionModeForwarding
+)
+
+// Resolver provides methods to resolve names in RAINS.
+type Resolver struct {
+	RootNameservers []string
+	Forwarders      []string
+	Mode            ResolutionMode
+	InsecureTLS     bool
+	DialTimeout     time.Duration
+	FailFast        bool
+}
+
+func New(rootNS, forwarders []string, mode ResolutionMode, insecureTLS bool) *Resolver {
+	return &Resolver{
+		RootNameservers: rootNS,
+		Forwarders:      forwarders,
+		Mode:            mode,
+		InsecureTLS:     insecureTLS,
+		DialTimeout:     defaultTimeout,
+		FailFast:        defaultFailFast,
+	}
+}
+
+func (r *Resolver) Lookup(name, context string) (*rainslib.RainsMessage, error) {
+	switch r.Mode {
+	case ResolutionModeRecursive:
+		return r.recursiveResolve(name, context)
+	case ResolutionModeForwarding:
+		q := r.nameToQuery(name, context, time.Now().Add(15*time.Second).UnixNano(), []rainslib.QueryOption{})
+		return r.forwardQuery(q)
+	default:
+		panic(fmt.Sprintf("Unsupported resolution mode: %v", r.Mode))
+	}
+}
+
+func (r *Resolver) nameToQuery(name, context string, expTime int64, opts []rainslib.QueryOption) rainslib.RainsMessage {
+	types := []rainslib.ObjectType{rainslib.OTIP4Addr, rainslib.OTIP6Addr, rainslib.OTDelegation, rainslib.OTServiceInfo}
+	return rainslib.NewQueryMessage(name, context, expTime, types, opts, rainslib.GenerateToken())
+}
+
+// waitResponse listens on the given parserframer until a message with the
+// specified token is received. If there is an error, it will be sent on
+// the error channel.
+func (r *Resolver) waitResponse(pf protoParser.ProtoParserAndFramer, token rainslib.Token, done chan *rainslib.RainsMessage, ec chan error) {
+	for pf.DeFrame() {
+		tok, err := pf.Token(pf.Data())
+		if err != nil {
+			ec <- fmt.Errorf("failed to get token from message: %v", err)
+			if r.FailFast {
+				return
+			}
+		}
+		msg, err := pf.Decode(pf.Data())
+		if err != nil {
+			ec <- fmt.Errorf("failed to parse bytes to RAINS message: %v", err)
+			if r.FailFast {
+				return
+			}
+		}
+		if tok != token {
+			ec <- fmt.Errorf("expected message with token %v but got %v", token, tok)
+			if r.FailFast {
+				return
+			}
+		} else {
+			done <- &msg
+			return
+		}
+	}
+}
+
+func (r *Resolver) forwardQuery(q rainslib.RainsMessage) (*rainslib.RainsMessage, error) {
+	if len(r.Forwarders) == 0 {
+		return nil, errors.New("forwarders must be specified to use this mode.")
+	}
+	errs := make([]error, 0)
+	for i, forwarder := range r.Forwarders {
+		glog.Infof("Connecting to forwarding resolver #%d: %v", i, forwarder)
+		d := &net.Dialer{
+			Timeout: r.DialTimeout,
+		}
+		conn, err := tls.DialWithDialer(d, "tcp", forwarder, &tls.Config{InsecureSkipVerify: r.InsecureTLS})
+		if err != nil {
+			glog.Warningf("Connection to fowarding resolver %d failed: %v", i, err)
+			errs = append(errs, err)
+			continue
+		}
+		defer conn.Close()
+		pf := protoParser.ProtoParserAndFramer{}
+		pf.InitStreams(conn, conn)
+		b, err := pf.Encode(q)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode message: %v", err)
+		}
+		if err := pf.Frame(b); err != nil {
+			return nil, fmt.Errorf("failed to frame message: %v", err)
+		}
+		done := make(chan *rainslib.RainsMessage)
+		ec := make(chan error)
+		go r.waitResponse(pf, q.Token, done, ec)
+		select {
+		case msg := <-done:
+			return msg, nil
+		case err := <-ec:
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("could not connect to any specified resolver, errors: %v", errs)
+}
+
+func mergeSubjectZone(subject, zone string) string {
+	if zone == "." {
+		return fmt.Sprintf("%s.", subject)
+	}
+	if subject == "" {
+		return zone
+	}
+	return fmt.Sprintf("%s.%s", subject, zone)
+}
+
+func NameToLabels(name string) ([]string, error) {
+	if !strings.HasSuffix(name, ".") {
+		return nil, fmt.Errorf("domain name must end with root qualifier '.', got %s", name)
+	}
+	parts := strings.Split(name, ".")
+	// Last element is empty because of root dot, so discard it.
+	return parts[:len(parts)-1], nil
+}
+
+// recursiveResolve starts at the root and follows delegations until it receives an answer.
+func (r *Resolver) recursiveResolve(name, context string) (*rainslib.RainsMessage, error) {
+	latestResolver := r.RootNameservers[0] // TODO: try multiple root nameservers.
+	var resp *rainslib.RainsMessage
+	for {
+		glog.Infof("connecting to resolver at address: %s to resolve %q", latestResolver, name)
+		d := &net.Dialer{
+			Timeout: r.DialTimeout,
+		}
+		conn, err := tls.DialWithDialer(d, "tcp", latestResolver, &tls.Config{InsecureSkipVerify: r.InsecureTLS})
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to resolver: %v", err)
+		}
+		defer conn.Close()
+		pf := protoParser.ProtoParserAndFramer{}
+		pf.InitStreams(conn, conn)
+		q := r.nameToQuery(name, context, time.Now().Add(15*time.Second).Unix(), []rainslib.QueryOption{})
+		glog.Infof("query is: %v", q)
+		b, err := pf.Encode(q)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode query: %v", err)
+		}
+		if err := pf.Frame(b); err != nil {
+			return nil, fmt.Errorf("failed to frame message: %v", err)
+		}
+		done := make(chan *rainslib.RainsMessage)
+		ec := make(chan error)
+		go r.waitResponse(pf, q.Token, done, ec)
+		select {
+		case msg := <-done:
+			resp = msg
+		case err := <-ec:
+			return nil, err
+		}
+		if len(resp.Content) == 0 {
+			return nil, errors.New("got empty response")
+		}
+		// Parse the response to find the service-info node.
+		for _, section := range resp.Content {
+			switch section.(type) {
+			case *rainslib.AssertionSection:
+				// Positive case
+				as := section.(*rainslib.AssertionSection)
+				sz := mergeSubjectZone(as.SubjectName, as.SubjectZone)
+				glog.Infof("Received a assertionsection for %s, %s, merged: %s", as.SubjectName, as.SubjectZone, sz)
+				if sz == name {
+					return resp, nil
+				}
+				var deleg interface{}
+				var serviceInfo *rainslib.ServiceInfo = nil
+				for _, obj := range as.Content {
+					if obj.Type == rainslib.OTDelegation {
+						glog.Infof("type of OTDelegation is %T", obj.Value)
+						deleg = obj.Value
+					}
+					if obj.Type == rainslib.OTServiceInfo {
+						serviceInfo = obj.Value.(*rainslib.ServiceInfo)
+					}
+				}
+				glog.Infof("deleg was %v", deleg)
+				if serviceInfo == nil {
+					return nil, fmt.Errorf("Incomplete delegation chain, last response = %v", resp)
+				}
+				latestResolver = fmt.Sprintf("%s:%d", serviceInfo.Name, serviceInfo.Port)
+			case *rainslib.ZoneSection:
+				// Negative case when a zone is returned to prove non-existance.
+				return resp, nil
+			}
+		}
+		return nil, fmt.Errorf("Didn't get delegation nor response")
+	}
+}

--- a/libresolve/lib_test.go
+++ b/libresolve/lib_test.go
@@ -1,0 +1,29 @@
+package libresolve
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// Checks whether the label parsing functionality is as expected.
+func TestNameToLabels(t *testing.T) {
+	badInput := "www.department.corp.jp"
+	expectedErr := fmt.Errorf("domain name must end with root qualifier '.', got %s", badInput)
+	res, err := NameToLabels(badInput)
+	if err.Error() != expectedErr.Error() {
+		t.Errorf("mismatched errors: want %v, got %v", expectedErr, err)
+	}
+	if res != nil {
+		t.Errorf("expected nil response but got %v", res)
+	}
+	goodInput := "www.post.ch."
+	expected := []string{"www", "post", "ch"}
+	res, err = NameToLabels(goodInput)
+	if err != nil {
+		t.Errorf("expected nil error, but got %v", err)
+	}
+	if !reflect.DeepEqual(res, expected) {
+		t.Errorf("mismatched return value, got %v, want %v", res, expected)
+	}
+}

--- a/rainsd/cache.go
+++ b/rainsd/cache.go
@@ -32,7 +32,7 @@ var pendingQueries pendingQueryCache
 
 //assertionCache contains a set of valid assertions where some of them might be expired.
 //An entry is marked as extrenal if it might be evicted by a LRU caching strategy.
-var assertionsCache assertionCache
+var assertionsCache *assertionCache
 
 //negAssertionCache contains for each zone and context an interval tree to find all shards and zones containing a specific assertion
 //for a zone the range is infinit: range "",""
@@ -80,7 +80,7 @@ func initCaches() {
 		counter:         safeCounter.New(Config.PendingQueryCacheSize),
 	}
 
-	assertionsCache = &assertionCacheImpl{
+	assertionsCache = &assertionCache{
 		cache:                  lruCache.New(),
 		counter:                safeCounter.New(Config.AssertionCacheSize),
 		zoneMap:                safeHashMap.New(),

--- a/rainsd/serverInfo.go
+++ b/rainsd/serverInfo.go
@@ -231,25 +231,6 @@ type pendingQueryCache interface {
 	Len() int
 }
 
-//assertionCache is used to store and efficiently lookup assertions
-type assertionCache interface {
-	//Add adds an assertion together with an expiration time (number of seconds since 01.01.1970) to
-	//the cache. It returns false if the cache is full and a non internal element has been removed
-	//according to some strategy. It also adds assertion to the consistency cache.
-	Add(assertion *rainslib.AssertionSection, expiration int64, isInternal bool) bool
-	//Get returns true and a set of assertions matching the given key if there exist some. Otherwise
-	//nil and false is returned.
-	Get(name, zone, context string, objType rainslib.ObjectType) ([]*rainslib.AssertionSection, bool)
-	//RemoveExpiredValues goes through the cache and removes all expired assertions from the
-	//assertionCache and the consistency cache.
-	RemoveExpiredValues()
-	//RemoveZone deletes all assertions in the assertionCache and consistencyCache of the given
-	//zone.
-	RemoveZone(zone string)
-	//Len returns the number of elements in the cache.
-	Len() int
-}
-
 type negativeAssertionCache interface {
 	//Add adds shard together with an expiration time (number of seconds since 01.01.1970) to
 	//the cache. It returns false if the cache is full and a non internal element has been removed

--- a/rainsd/serverInterfaceImpl.go
+++ b/rainsd/serverInterfaceImpl.go
@@ -772,7 +772,7 @@ type assertionExpiration struct {
  * such that we can remove all entries of a zone in case of misbehavior or inconsistencies.
  * It does not support any context
  */
-type assertionCacheImpl struct {
+type assertionCache struct {
 	cache                  *lruCache.Cache
 	counter                *safeCounter.Counter
 	zoneMap                *safeHashMap.Map
@@ -780,17 +780,33 @@ type assertionCacheImpl struct {
 	mux                    sync.Mutex     //protects entriesPerAssertionMap from simultaneous access
 }
 
+func mergeSubjectZone(subject, zone string) string {
+	if zone == "." {
+		return fmt.Sprintf("%s.", subject)
+	}
+	if subject == "" {
+		return zone
+	}
+	return fmt.Sprintf("%s.%s", subject, zone)
+}
+
 //assertionCacheMapKey returns the key for assertionCacheImpl.cache based on the assertion
 func assertionCacheMapKey(name, zone, context string, oType rainslib.ObjectType) string {
-	key := fmt.Sprintf("%s %s %s %d", name, zone, context, oType)
+	key := fmt.Sprintf("%s %s %d", mergeSubjectZone(name, zone), context, oType)
 	log.Debug("assertionCacheMapKey", "key", key)
+	return key
+}
+
+func assertionCacheMapKeyFQDN(fqdn, context string, oType rainslib.ObjectType) string {
+	key := fmt.Sprintf("%s %s %d", fqdn, context, oType)
+	log.Debug("assertionCacheMapKeyFQDN", "key", key)
 	return key
 }
 
 //Add adds an assertion together with an expiration time (number of seconds since 01.01.1970) to
 //the cache. It returns false if the cache is full and an element was removed according to least
 //recently used strategy. It also adds the shard to the consistency cache.
-func (c *assertionCacheImpl) Add(a *rainslib.AssertionSection, expiration int64, isInternal bool) bool {
+func (c *assertionCache) Add(a *rainslib.AssertionSection, expiration int64, isInternal bool) bool {
 	isFull := false
 	consistCache.Add(a)
 	for _, o := range a.Content {
@@ -859,17 +875,11 @@ func (c *assertionCacheImpl) Add(a *rainslib.AssertionSection, expiration int64,
 }
 
 // zoneHierarchy returns a slice of domain names upto the root to try and find a match in the cache.
-func zoneHierarchy(name, zone string) []string {
-	if zone == "." {
-		if name == "" {
-			return []string{zone}
-		}
-		return []string{fmt.Sprintf("%s.", name), zone}
+func zoneHierarchy(fqdn string) []string {
+	labels := strings.Split(fqdn, ".")
+	if len(labels) == 2 {
+		return []string{labels[0] + "."}
 	}
-	if name != "" {
-		zone = fmt.Sprintf("%s.%s", name, zone)
-	}
-	labels := strings.Split(zone, ".")
 	attempts := make([]string, 0)
 	for i := 0; i < len(labels)-1; i++ {
 		attempts = append(attempts, strings.Join(labels[i:], "."))
@@ -879,22 +889,25 @@ func zoneHierarchy(name, zone string) []string {
 
 //Get returns true and a set of assertions matching the given key if there exist some. Otherwise
 //nil and false is returned.
-func (c *assertionCacheImpl) Get(name, zone, context string, objType rainslib.ObjectType) ([]*rainslib.AssertionSection, bool) {
-	log.Debug("get", "name", name, "zone", zone)
-	hierarchy := zoneHierarchy(name, zone)
-	log.Debug("hierarchy is ", "hierarchy", hierarchy)
+// If strict is true then only a direct match for the provided FQDN is looked up.
+// Otherwise, a search up the domain name hierarchy is performed to get the topmost match.
+func (c *assertionCache) Get(fqdn, context string, objType rainslib.ObjectType, strict bool) ([]*rainslib.AssertionSection, bool) {
+	log.Debug("get", "fqdn", fqdn)
 	var v interface{}
 	var ok bool
-	for _, fqdn := range hierarchy {
-		log.Info("Trying get with fqdn", "fqdn", fqdn)
-		subject, zone, err := fqdnToSubjectZone(fqdn)
-		if err != nil {
-			panic(fmt.Sprintf("Attempted to lookup bad key in cache: %v", fqdn))
+	if strict {
+		v, ok = c.cache.Get(assertionCacheMapKeyFQDN(fqdn, context, objType))
+	} else {
+		hierarchy := zoneHierarchy(fqdn)
+		log.Debug("hierarchy is ", "hierarchy", hierarchy)
+		for _, fqdn := range hierarchy {
+			log.Info("Trying get with fqdn", "fqdn", fqdn)
+			v, ok = c.cache.Get(assertionCacheMapKeyFQDN(fqdn, context, objType))
+			if ok {
+				break
+			}
 		}
-		v, ok = c.cache.Get(assertionCacheMapKey(subject, zone, context, objType))
-		if ok {
-			break
-		}
+
 	}
 	if !ok {
 		return nil, false
@@ -914,7 +927,7 @@ func (c *assertionCacheImpl) Get(name, zone, context string, objType rainslib.Ob
 
 //RemoveExpiredValues goes through the cache and removes all expired assertions from the
 //assertionCache and the consistency cache.
-func (c *assertionCacheImpl) RemoveExpiredValues() {
+func (c *assertionCache) RemoveExpiredValues() {
 	for _, v := range c.cache.GetAll() {
 		value := v.(*assertionCacheValue)
 		deleteCount := 0
@@ -949,7 +962,7 @@ func (c *assertionCacheImpl) RemoveExpiredValues() {
 }
 
 //RemoveZone deletes all assertions in the assertionCache and consistencyCache of the given zone.
-func (c *assertionCacheImpl) RemoveZone(zone string) {
+func (c *assertionCache) RemoveZone(zone string) {
 	if set, ok := c.zoneMap.Remove(zone); ok {
 		for _, key := range set.(*safeHashMap.Map).GetAllKeys() {
 			v, ok := c.cache.Remove(key)
@@ -978,7 +991,7 @@ func (c *assertionCacheImpl) RemoveZone(zone string) {
 }
 
 //Len returns the number of elements in the cache.
-func (c *assertionCacheImpl) Len() int {
+func (c *assertionCache) Len() int {
 	return c.counter.Value()
 }
 

--- a/rainsdig/rainsdig.go
+++ b/rainsdig/rainsdig.go
@@ -20,7 +20,7 @@ import (
 )
 
 var anyQuery = []rainslib.ObjectType{rainslib.OTName, rainslib.OTIP4Addr,
-	rainslib.OTIP6Addr, rainslib.OTDelegation, rainslib.OTServiceInfo}
+	rainslib.OTIP6Addr, rainslib.OTDelegation, rainslib.OTServiceInfo, rainslib.OTRedirection}
 
 //TODO add default values to description
 var revLookup = flag.String("x", "", "Reverse lookup, addr is an IPv4 address in dotted-decimal notation, or a colon-delimited IPv6 address.")

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -39,12 +39,13 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Failed to execute query: %v", err)
 	}
-	for _, section := range result.Content {
+	for i, section := range result.Content {
+		glog.Infof("Printing section %d", i)
 		switch section.(type) {
 		case *rainslib.AssertionSection, *rainslib.ShardSection, *rainslib.ZoneSection, *rainslib.QuerySection, *rainslib.NotificationSection,
 			*rainslib.AddressAssertionSection, *rainslib.AddressQuerySection, *rainslib.AddressZoneSection:
 			parser := zoneFileParser.Parser{}
-			fmt.Printf(parser.Encode(section))
+			fmt.Printf("%s\n", parser.Encode(section))
 		default:
 			glog.Warningf("Received an unexpected section type in response: %T, %v", section, section)
 		}

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/golang/glog"
+	"strings"
+
+	"github.com/netsec-ethz/rains/libresolve"
+	"github.com/netsec-ethz/rains/rainslib"
+	"github.com/netsec-ethz/rains/utils/zoneFileParser"
+)
+
+var (
+	name          = flag.String("name", "", "Name to query the server for.")
+	context       = flag.String("context", ".", "Context in which to query.")
+	rootResolvers = flag.String("root", "", "Comma separated list of root resolvers to query.")
+	fwdResolvers  = flag.String("fwd", "", "Comma separated list of recursive resolvers to query.")
+	insecureTLS   = flag.Bool("insecureTLS", false, "Whether to validate the TLS certificate of the server.")
+)
+
+func main() {
+	flag.Parse()
+	glog.Infof("Starting resolver client.")
+	if *name == "" {
+		glog.Fatalf("-name flag must be specified.")
+	}
+	var resolver *libresolve.Resolver
+	if *rootResolvers != "" {
+		roots := strings.Split(*rootResolvers, ",")
+		resolver = libresolve.New(roots, nil, libresolve.ResolutionModeRecursive, *insecureTLS)
+	} else if *fwdResolvers != "" {
+		forwarders := strings.Split(*fwdResolvers, ",")
+		resolver = libresolve.New(nil, forwarders, libresolve.ResolutionModeForwarding, *insecureTLS)
+	} else {
+		glog.Fatal("At least one of -root or -fwd must be specified.")
+	}
+	result, err := resolver.Lookup(*name, *context)
+	if err != nil {
+		glog.Fatalf("Failed to execute query: %v", err)
+	}
+	for _, section := range result.Content {
+		switch section.(type) {
+		case *rainslib.AssertionSection, *rainslib.ShardSection, *rainslib.ZoneSection, *rainslib.QuerySection, *rainslib.NotificationSection,
+			*rainslib.AddressAssertionSection, *rainslib.AddressQuerySection, *rainslib.AddressZoneSection:
+			parser := zoneFileParser.Parser{}
+			fmt.Printf(parser.Encode(section))
+		default:
+			glog.Warningf("Received an unexpected section type in response: %T, %v", section, section)
+		}
+	}
+}

--- a/utils/zoneFileParser/zoneFileDecoder.go
+++ b/utils/zoneFileParser/zoneFileDecoder.go
@@ -13,6 +13,28 @@ import (
 	"golang.org/x/crypto/ed25519"
 )
 
+// validZone is the canonical source of truth if the provided string is a zone.
+func validZone(zone string) bool {
+	if zone == "." {
+		return true
+	}
+	if !strings.HasSuffix(zone, ".") {
+		return false
+	}
+	labels := strings.Split(zone, ".")
+	for i := 0; i < len(labels)-1; i++ {
+		if labels[i] == "" {
+			return false
+		}
+	}
+	return true
+}
+
+// validSubject is the canonical source of truth if the provided string is a subject.
+func validSubject(subject string) bool {
+	return len(subject) > 0 && !strings.Contains(subject, ".")
+}
+
 // decodeZone expects as input a scanner holding the data of a zone represented in the zone file format.
 // It returns all assertions present in the zone file or an error in case the zone file is malformed.
 // The error indicates what value was expected and in which line of the input the error occurred.
@@ -24,6 +46,9 @@ func decodeZone(scanner *WordScanner) ([]*rainslib.AssertionSection, error) {
 	}
 	scanner.Scan()
 	zone := scanner.Text()
+	if !validZone(zone) {
+		return nil, fmt.Errorf("%q is not a valid zone", zone)
+	}
 	scanner.Scan()
 	context := scanner.Text()
 	scanner.Scan()
@@ -99,6 +124,9 @@ func decodeAssertion(context, zone string, scanner *WordScanner) (*rainslib.Asse
 	}
 	scanner.Scan()
 	name := scanner.Text()
+	if !validSubject(name) {
+		return nil, fmt.Errorf("%q is not a valid subject", name)
+	}
 	missingBracket := true
 	//skip subjectZone and context if they are present
 	for i := 0; i < 3; i++ {

--- a/utils/zoneFileParser/zoneFileDecoder.go
+++ b/utils/zoneFileParser/zoneFileDecoder.go
@@ -30,9 +30,9 @@ func validZone(zone string) bool {
 	return true
 }
 
-// validSubject is the canonical source of truth if the provided string is a subject.
+// validSubject ensures that a subject does not end with a dot, to prevent errors concatenating.
 func validSubject(subject string) bool {
-	return len(subject) > 0 && !strings.Contains(subject, ".")
+	return !strings.HasSuffix(subject, ".")
 }
 
 // decodeZone expects as input a scanner holding the data of a zone represented in the zone file format.

--- a/utils/zoneFileParser/zoneFileDecoder_test.go
+++ b/utils/zoneFileParser/zoneFileDecoder_test.go
@@ -547,10 +547,10 @@ func TestDecodeZone(t *testing.T) {
 	}{
 		{zoneEncodings[0], []*rainslib.AssertionSection{zones[0].Content[0].(*rainslib.AssertionSection), zones[0].Content[1].(*rainslib.ShardSection).Content[0]}, ""},
 		{"WrongType", nil, "malformed zonefile: expected ':Z:' got: WrongType at line 1"},
-		{":Z: ch . ", nil, "malformed zonefile: expected '[' got:  at line 2"},
-		{":Z: ch . [ WrongType", nil, "malformed zonefile: expected ':A:' or ':S:' but got WrongType at line 1"},
-		{":Z: ch . [ :A: ", nil, "error decoding assertion: expected '[' but got  at line 2"},
-		{":Z: ch . [ :S: ", nil, "expected '[' but got  at line 2"},
+		{":Z: ch. . ", nil, "malformed zonefile: expected '[' got:  at line 2"},
+		{":Z: ch. . [ WrongType", nil, "malformed zonefile: expected ':A:' or ':S:' but got WrongType at line 1"},
+		{":Z: ch. . [ :A: ", nil, "error decoding assertion: expected '[' but got  at line 2"},
+		{":Z: ch. . [ :S: ", nil, "expected '[' but got  at line 2"},
 	}
 	for i, test := range tests {
 		scanner := NewWordScanner([]byte(test.input))

--- a/utils/zoneFileParser/zoneFileParserTestData.go
+++ b/utils/zoneFileParser/zoneFileParserTestData.go
@@ -290,12 +290,12 @@ func getZonesAndEncodings() ([]*rainslib.ZoneSection, []string) {
 	zone0 := &rainslib.ZoneSection{
 		Content:     []rainslib.MessageSectionWithSigForward{assertions[0], shards[1]},
 		Context:     ".",
-		SubjectZone: "ch",
+		SubjectZone: "ch.",
 		Signatures:  []rainslib.Signature{getSignature()},
 	}
 	zone1 := &rainslib.ZoneSection{
 		Context:     ".",
-		SubjectZone: "ch",
+		SubjectZone: "ch.",
 		Signatures:  []rainslib.Signature{getSignature()},
 	}
 
@@ -304,8 +304,8 @@ func getZonesAndEncodings() ([]*rainslib.ZoneSection, []string) {
 
 	//encodings
 	encodings := []string{}
-	encodings = append(encodings, fmt.Sprintf(":Z: ch . [\n%s%s\n%s%s\n]", indent4, assertionEncodings[0], indent4, shardEncodings[1])) //when not used for signing, it does not copy context and subjectZone to contained shards and assertions
-	encodings = append(encodings, ":Z: ch . [\n]")
+	encodings = append(encodings, fmt.Sprintf(":Z: ch. . [\n%s%s\n%s%s\n]", indent4, assertionEncodings[0], indent4, shardEncodings[1])) //when not used for signing, it does not copy context and subjectZone to contained shards and assertions
+	encodings = append(encodings, ":Z: ch. . [\n]")
 
 	return zones, encodings
 }

--- a/utils/zoneFileParser/zoneSanityCheck.go
+++ b/utils/zoneFileParser/zoneSanityCheck.go
@@ -1,0 +1,72 @@
+package zoneFileParser
+
+import (
+	"fmt"
+	"github.com/netsec-ethz/rains/rainslib"
+
+	log "github.com/inconshreveable/log15"
+)
+
+func mergeSubjectZone(subject, zone string) string {
+	if zone == "." {
+		return fmt.Sprintf("%s.", subject)
+	}
+	if subject == "" {
+		return zone
+	}
+	return fmt.Sprintf("%s.%s", subject, zone)
+}
+
+// ValidateZoneRedirects checks that each :redir: in the zone is resolvable.
+func ValidateZoneRedirects(in []*rainslib.AssertionSection) error {
+	unresolved := make(map[string]string)
+	// A concrete assertion is one which resolves to an internet address.
+	concreteAssertions := make(map[string]bool)
+	for _, as := range in {
+		fqdn := mergeSubjectZone(as.SubjectName, as.SubjectZone)
+		for _, c := range as.Content {
+			if c.Type == rainslib.OTRedirection {
+				target := c.Value.(string)
+				if _, ok := unresolved[fqdn]; ok {
+					return fmt.Errorf("assertion redeclared in zone: %v", fqdn)
+				}
+				unresolved[fqdn] = target
+			}
+			if c.Type == rainslib.OTServiceInfo {
+				si := c.Value.(rainslib.ServiceInfo)
+				if _, ok := unresolved[fqdn]; ok {
+					return fmt.Errorf("assertion redeclared in zone: %v", fqdn)
+				}
+				unresolved[fqdn] = si.Name
+			}
+			if c.Type == rainslib.OTIP4Addr || c.Type == rainslib.OTIP6Addr {
+				concreteAssertions[fqdn] = true
+			}
+		}
+	}
+	log.Info("vzr", "unresolved", unresolved, "concrete", concreteAssertions)
+	// For each name which is the target of a redirect, check that it can be resolved
+	// using the information in this zone alone. We must take special care of the fact
+	// that there may be loops.
+	for key, _ := range unresolved {
+		seen := make(map[string]bool)
+		target := key
+		for {
+			if _, ok := seen[target]; ok {
+				return fmt.Errorf("redirect loop for key=%v", key)
+			}
+			// Target is another redirect.
+			if t, ok := unresolved[target]; ok {
+				target = t
+				seen[key] = true
+				continue
+			}
+			// Target is a concrete assertion.
+			if _, ok := concreteAssertions[target]; ok {
+				break
+			}
+			return fmt.Errorf("could not resolve redirect for name: %v", key)
+		}
+	}
+	return nil
+}

--- a/utils/zoneFileParser/zoneSanityCheck_test.go
+++ b/utils/zoneFileParser/zoneSanityCheck_test.go
@@ -1,0 +1,27 @@
+package zoneFileParser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateZoneRedirects(t *testing.T) {
+	p := Parser{}
+	valid := ":Z: . . [ :A: example [ :redir: nic.example. ] :A: nic.example [ :srv: ns1.example. 2345 10 ] :A: ns1.example [ :ip4: 127.0.0.1 ] ]"
+	as, err := p.Decode([]byte(valid))
+	if err != nil {
+		t.Fatalf("malformed zonefile 'valid' hardcoded in test: %v", err)
+	}
+	if err := ValidateZoneRedirects(as); err != nil {
+		t.Errorf("expected no errors for valid zonefile but got %v", err)
+	}
+	missingTarget := ":Z: . . [ :A: example [ :redir: nic.example. ] :A: nic.example [ :srv: ns1.example. 2345 10 ] ]"
+	as, err = p.Decode([]byte(missingTarget))
+	if err != nil {
+		t.Fatalf("malformed zonefile 'missingTarget' hardcoded in test: %v", err)
+	}
+	expectErrPrefix := "could not resolve redirect for name"
+	if err := ValidateZoneRedirects(as); !strings.HasPrefix(err.Error(), expectErrPrefix) {
+		t.Errorf("mismatched error in validateZoneRedirects, got %q, want prefix %q", err.Error(), expectErrPrefix)
+	}
+}

--- a/utils/zoneFileParser/zoneSanityCheck_test.go
+++ b/utils/zoneFileParser/zoneSanityCheck_test.go
@@ -24,4 +24,13 @@ func TestValidateZoneRedirects(t *testing.T) {
 	if err := ValidateZoneRedirects(as); !strings.HasPrefix(err.Error(), expectErrPrefix) {
 		t.Errorf("mismatched error in validateZoneRedirects, got %q, want prefix %q", err.Error(), expectErrPrefix)
 	}
+	loopTarget := ":Z: . . [ :A: example [ :redir: nic.example. ] :A: nic.example [ :redir: example. ] ]"
+	as, err = p.Decode([]byte(loopTarget))
+	if err != nil {
+		t.Fatalf("malformed zonefile 'loopTarget' hardcoded in test: %v", err)
+	}
+	expectErrPrefix = "redirect loop for key"
+	if err := ValidateZoneRedirects(as); !strings.HasPrefix(err.Error(), expectErrPrefix) {
+		t.Errorf("mismatched error in validateZoneRedirects, got %q, want prefix %q", err.Error(), expectErrPrefix)
+	}
 }


### PR DESCRIPTION
Completed the prototype of the recursive resolver library. Now a domain can have a `:redir:` which points to a glue assertion which contains a `:srv:` which points to the nameserver which should be queried.

The `resolve` binary now handles the recursive querying logic, which is eventually going to be ported back into `rainsdig` when it is more feature complete.

The integration tests also have been updated to use this new logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/rains/86)
<!-- Reviewable:end -->
