### PR TITLE
Design of the zone manager and zonefile format. goYACC implementation

### DIFF
--- a/design-zone-manager.md
+++ b/design-zone-manager.md
@@ -1,0 +1,52 @@
+# How to manage a zone
+
+This document presents a design how a zone authority could manage its zone.
+Always when something needs to be changed on a current section or a section has
+to be added or removed the zone authority handles it and makes sure that the
+rainsd server gets a signed and updated section. We envision three components a
+zone authority must have to efficiently manage its zone which we are going to
+describe in detail below.
+
+1. zone manager (zoneManager)
+2. zone publisher (zonePub)
+3. rains publisher (rainsPub)
+
+## Zone manager
+
+The zone manager is responsible for the administrative part. This involves to
+deal with clients, manage contracts and make sure that the content of the signed
+contracts are realized. This also means that it must keep the zone file up to
+date. It might include grouping assertions into shards, sorting the zone, and
+making sure that no entry violates the protocol specification or the zone's
+policy. But it could as well delegate this task to the zone publisher. The zone
+manager also invokes the zone publisher periodically to publish all or parts of
+its sections to the system according to its policy. It handles next-key
+assertions from its subzones and updates the delegation assertion's public key
+in the zonefile accordingly
+
+## Zone publisher
+
+The zone publisher is a small, highly configurable command line tool. It uses
+the rains publisher library which performs most of the work. It is periodically
+invoked by the zone manager to push updated zone information to the rains
+servers. It loads the information what to push from the zonefile provided by the
+zone manager. The configurations are loaded from a config file and each of them
+can be overwritten by providing the updated value as a command line flag. If the
+signature meta data are not provided in the zonefile, the zone publisher
+calculates them for each section according to its configuration (e.g. to expire
+assertions evenly over a time interval). It can optionally make sure that the
+new delegation assertion for this zone is present on all authoritative rains
+servers and that the newly signed zone information is consistent before encoding
+and pushing it to the rains servers. In case one of the rains servers has not
+been able to correctly receive the update, the zone publisher raises an alarm.
+
+## RAINS publisher
+
+Rains publisher (rainsPub) is designed as a library to do most of the work
+involved in updating zone information such as sign sections (assertions, shards,
+and zones), establish connections to all authoritative servers and push the
+newly signed sections to them, etc. It reports back to the zone publisher in
+case errors have occurred. Currently, the private key is stored on the rainsPub
+server but in the future an airgapping mechanism might be used to increase
+security. RainsPub ignores any information sent from the rains servers except
+notifications concerning a previously pushed section from rainsPub.

--- a/design-zonefile-format.md
+++ b/design-zonefile-format.md
@@ -111,13 +111,13 @@ The above format in BNF.
 <infra> ::= <infrabody> | <infra> <infrabody>
 <extra> ::= <extrabody> | <extra> <extrabody>
 <next> ::= <nextbody> | <next> <nextbody>
-<namebody> ::= ":name:" <cname> "[" <objectTypes> "]"
+<namebody> ::= ":name:" <alias> "[" <objectTypes> "]"
 <ip6body> ::= ":ip6:" <ip6Addr>
 <ip4body> ::= ":ip4:" <ip4Addr>
 <redirbody> ::= ":redir:" <redirname>
 <delegbody> ::= ":deleg:" ":ed25519:" <keyphase> <publicKeyData>
 <namesetbody> ::= ":nameset:" <freeText>
-<certbody> ::= ":cert:" <protocolType> <certificatUsage> <hashType> <certData>
+<certbody> ::= ":cert:" <protocolType> <certificateUsage> <hashType> <certData>
 <srvbody> ::= ":srv:" <serviceName> <port> <priority>
 <regrbody> ::= ":regr:" <freeText>
 <regtbody> ::= ":regt:" <freeText>
@@ -130,7 +130,7 @@ The above format in BNF.
                  ":infra:" | ":extra:" | ":next:" |
 <freeText> ::= <word> | <freeText> <word>
 <protocolType> ::= ":unspecified:" | ":tls:"
-<certificatUsage> ::= ":trustAnchor:" | ":endEntity:"
+<certificateUsage> ::= ":trustAnchor:" | ":endEntity:"
 <hashType> ::= ":noHash:" | ":sha256:" | ":sha384:" | ":sha512:"
 <annotation> ::= "(" <annotationBody> ")"
 <annotationBody> ::= <signature> | <annotationBody> <signature>

--- a/design-zonefile-format.md
+++ b/design-zonefile-format.md
@@ -1,0 +1,184 @@
+# Zone File Format
+
+A zone file is a text file containing a textual representation of RAINS entries.
+Typically, a zone file describes all entries of a zone. But it can also be used
+to pre-load entries at startup of a caching server or a cache to output the
+currently stored entries. It is RAINS analog to DNS's zone file format defined
+in section 5 of [2], used by BIND [3] and many more.
+
+## Format
+
+A zone file contains a section or a sequence of sections. A section typically
+starts on a new line. Each section consists of several elements. At least one
+white space (space, tab, return) acts as a delimiter between elements. A comment
+starts with a ";" (semicolon) which results in the rest of the line being
+ignored by the parser. Empty lines are allowed anywhere in the file, with or
+without comments.
+
+Parentheses "()", brackets "[]" and types (type name between semicolons e.g.
+:ip4:) are static terms. Each term starting with a lowercase character stands
+for an arbitrary string value. The meaning of this value is specified in the
+RAINS data model. Similar to regex we use the following special characters which
+are not part of the syntax.
+
+- "{}" to group terms (as parenthesis are part of the syntax)
+- "|" either term on the left or term on the right (not both)
+- "\*" arbitrary number of occurrences of the previous term (including none)
+- "\+" at least one occurrence of the previous term
+
+### Special Encodings
+
+- ";" represents the beginning of a comment. The remainder of the line is
+  ignored.
+- "<" represents the nil value of a shard's rangeFrom
+- ">" represents the nil value of a shard's rangeTo
+
+### Zone Format Specification
+
+- Zone := Z|ZA
+- Z := :Z: subject-zone context [ {Assertion|Shard}* ]
+- ZA := Z ( Annotation* )
+
+### Shard Format Specification
+
+- Shard := BS|CS|BSA|CSA
+- BS := :S: subject-zone context rangeFrom rangeUntil [ Assertion* ]
+- CS := :S: rangeFrom rangeUntil [ Assertion* ]
+- BSA := BS ( Annotation* )
+- CSA := CS ( Annotation* )
+
+### Assertion Format Specification
+
+- Assertion := BA|CA|BAA|CAA
+- BA := :A: subject-name subject-zone context [ Object+ ]
+- CA := :A: subject-name [ Object+ ]
+- BAA := BA ( Annotation* )
+- CAA := CA ( Annotation* )
+
+### Object Format Specification
+
+- Object := Name|IP6|IP4|Redir|Deleg|Nameset|Cert|Srv|Regr|Regt|Infra|Extra|Next
+- Name := :name: name [ ObjectType+ ]
+- IP6 := :ip4: ip4
+- IP4 := :ip6: ip6
+- Redir := :redir: name
+- Deleg := :deleg: algorithm keyphase publicKey
+- Nameset := :nameset: expr
+- Cert := :cert: protocolType usageType hashType certificate
+- Srv := :srv: name port priority
+- Regr := :regr: registrar
+- Regt := :regt: registrant
+- Infra := :infra: algorithm keyphase publicKey
+- Extra := :extra: keyspace algorithm keyphase publicKey
+- Next := :next: algorithm keyphase publicKey validSince validUntil
+- ObjectType := :name:|:ip6:|:ip4:|:redir:|:deleg:|:nameset:|:cert:|:srv:|:regr:|:regt:|:infra:|:extra:|:next:
+
+### Annotation Format Specification
+
+- Annotation := Signature
+
+### Signature Format Specification
+
+- Signature := SM|SMS
+- SM := :sig: algorithm keyspace keyphase validSince validUntil
+- SMS := SM signature
+
+## BNF
+
+The above format in BNF.
+
+<sections> ::= "" | <sections> <assertion> | <sections> <shard> | <sections> <zone>
+<zone> ::= <zoneBody> | <zoneBody> <annotation>
+<zoneBody> ::= ":Z:" <subjectZone> <context> "[" <zoneContent> "]"
+<zoneContent> ::= "" | <zoneContent> <assertion> | <zoneContent> <shard>
+<shard> ::= <shardBody> | <shardBody> <annotation>
+<shardBody> ::= ":S:" <shardRange> "[" <shardContent> "]" | ":S:" <subjectZone> <context> <shardRange> "[" <shardContent> "]"
+<shardRange> ::= <rangeBegin> <rangeEnd> | <rangeBegin> ">" | "<" <rangeEnd> | "<" ">"
+<shardContent> ::= "" | <shardContent> <assertion>
+<assertion> ::= <assertionBody> | <assertionBody> <annotation>
+<assertionBody> ::= ":A:" <name> "[" <objects> "]" | ":A:" <name> <subjectZone> <context> "[" <objects> "]"
+<objects> ::= <name> | <ip6> | <ip4> | <redir> | <deleg> | <nameset> | <cert> | <srv> | <regr> | <regt> | <infra> | <extra> | <next>
+<name> ::= <namebody> | <name> <namebody>
+<ip6> ::= <ip6body> | <ip6> <ip6body>
+<ip4> ::= <ip4body> | <ip4> <ip4body>
+<redir> ::= <redirbody> | <redir> <redirbody>
+<deleg> ::= <delegbody> | <deleg> <delegbody>
+<nameset> ::= <namesetbody> | <nameset> <namesetbody>
+<cert> ::= <certbody> | <cert> <certbody>
+<srv> ::= <srvbody> | <srv> <srvbody>
+<regr> ::= <regrbody> | <regr> <regrbody>
+<regt> ::= <regtbody> | <regt> <regtbody>
+<infra> ::= <infrabody> | <infra> <infrabody>
+<extra> ::= <extrabody> | <extra> <extrabody>
+<next> ::= <nextbody> | <next> <nextbody>
+<namebody> ::= ":name:" <cname> "[" <objectTypes> "]"
+<ip6body> ::= ":ip6:" <ip6Addr>
+<ip4body> ::= ":ip4:" <ip4Addr>
+<redirbody> ::= ":redir:" <redirname>
+<delegbody> ::= ":deleg:" ":ed25519:" <keyphase> <publicKeyData>
+<namesetbody> ::= ":nameset:" <freeText>
+<certbody> ::= ":cert:" <protocolType> <certificatUsage> <hashType> <certData>
+<srvbody> ::= ":srv:" <serviceName> <port> <priority>
+<regrbody> ::= ":regr:" <freeText>
+<regtbody> ::= ":regt:" <freeText>
+<infrabody> ::= ":infra:" ":ed25519:" <keyphase> <publicKeyData>
+<extrabody> ::= ":extra:" ":ed25519:" <keyphase> <publicKeyData>
+<nextbody> ::= ":next:" ":ed25519:" <keyphase> <publicKeyData> <validFrom> <validSince>
+<objectTypes> ::= <objectType> | <objectTypes> <objectType>
+<objectType> ::= ":name:" | ":ip6:" | ":ip4:" | ":redir:" | ":deleg:" |  
+                 ":nameset:" | ":cert:" | ":srv:" | ":regr:" | ":regt:" |  
+                 ":infra:" | ":extra:" | ":next:" |
+<freeText> ::= <word> | <freeText> <word>
+<protocolType> ::= ":unspecified:" | ":tls:"
+<certificatUsage> ::= ":trustAnchor:" | ":endEntity:"
+<hashType> ::= ":noHash:" | ":sha256:" | ":sha384:" | ":sha512:"
+<annotation> ::= "(" <annotationBody> ")"
+<annotationBody> ::= <signature> | <annotationBody> <signature>
+<signature> ::= <sigMetaData> | <sigMetaData> <signatureData>
+<sigMetaData> ::= ":sig:" ":ed25519:" ":rains:" <keyphase> <validFrom> <validSince>
+
+TODO CFE define the types of some of the non terminals. Most of them are strings.
+
+## Implementation
+
+- readLineFunction: reads next line, separates line by comment delimiter,
+  returns scanner to the content part or false if end of line
+- parseFunction: takes a scanner as input which splits on white spaces. If the
+  scanner is at the end, invoke readLineFunction() to override scanner and
+  continue parsing. If no new entries and last entry parsed correctly, return
+  content else error.
+
+## Example
+
+An zone file example for the domain example.com.
+
+:Z: example com. [  
+    :S: < > [  
+        :A: bar  [ :ip4: 192.0.2.0 ]  
+        :A: baz  [ :ip4: 192.0.2.1 ]  
+        :A: foo [  
+                :ip6:      2001:db8::  
+                :ip4:      192.0.2.2  
+        ]  
+    ]  
+    :S: bar foo [  
+        :A: baz  [ :ip4: 192.0.2.1 ] (TODO CFE add sig meta data)  
+    ] (TODO CFE add sig meta data)  
+]
+or equivalent
+:S: example com. < > [  
+    :A: bar  [ :ip4: 192.0.2.0 ]  
+    :A: baz  [ :ip4: 192.0.2.1 ]  
+    :A: foo [  
+            :ip6:      2001:db8::  
+            :ip4:      192.0.2.2  
+    ]  
+]  
+:S: example com. bar foo [  
+    :A: baz  [ :ip4: 192.0.2.1 ] (TODO CFE add sig meta data)  
+] (TODO CFE add sig meta data)  
+
+## Bibliography
+[1] DNS zone file https://en.wikipedia.org/wiki/Zone_file
+[2] DNS zone file format, Section 5 https://tools.ietf.org/html/rfc1035
+[3] BIND https://www.isc.org/downloads/bind/

--- a/man/zpub.md
+++ b/man/zpub.md
@@ -50,7 +50,6 @@ program. Keys are to be specified in a top-level JSON map.
   stored at the provided path
 * `DoPublish`: Sends the signed sections to all authoritative rainsd servers if
   it is set to true
-* ``:
 
 ## Issues
 

--- a/man/zpub.md
+++ b/man/zpub.md
@@ -1,0 +1,57 @@
+rzpub(1) -- A RAINS publishing tool
+===========================
+
+## DESCRIPTION
+
+rzpub (short for RAINS zone publisher) is a tool for pushing sections to RAINS
+servers from the command line. It reads a zone file and sends it to all
+authoritative RAINS servers specified in the config file. The default location
+of the config file is at [TODO add location] and of the zone file at [TODO add
+location] if not told otherwise by a command line flag.
+
+## OPTIONS
+
+The following options can be specified in the configuration file for the rzpub
+program. Keys are to be specified in a top-level JSON map.
+
+* `ZonefilePath`: Path to the zonefile
+* `ConfigPath`: Path to the config file
+* `AuthServers`: Authoritative server addresses to which the sections in the
+  zone file are forwarded
+* `PrivateKeyPath`: Path to a file storing the private keys. Each line contains
+  a key phase and a private key encoded in hexadecimal separated by a space.
+* `doSharding`: If set to true, only assertions in the zonefile are considered
+  and grouped into shards based on configuration
+* `NofAssertionsPerShard`: Defines the number of assertions per shard if
+  sharding is performed
+* `AddSignatureMetaData`: If set to true, adds signature meta data to sections
+* `SignatureAlgorithm`: Algorithm to be used for signing
+* `KeyPhase`: Defines which private key is used for signing
+* `SigValidSince`: Defines the starting point of the SigSigningInterval for the
+  Signature validSince values. Assertions' validSince values are uniformly
+  spread out over this interval
+* `SigValidUntil`: Defines the starting point of the SigSigningInterval for the
+  Signature validUntil values. Assertions' validUntil values are uniformly
+  spread out over this interval
+* `SigSigningInterval`: Defines the time interval over which the assertions'
+  signature lifetimes are uniformly spread out.
+* `DoConsistencyCheck`: Performs all consistency checks if set to true. The
+  check involves: TODO CFE
+* `SortShards`: Makes sure that the assertions withing the shard are sorted.
+* `SigNotExpired`: Checks that all signatures have a validUntil time in the
+  future
+* `CheckStringFields`: Checks that none of the assertions' text fields contain
+  type markers which are part of the protocol syntax (TODO CFE use more precise
+  vocabulary)
+* `DoSigning`: Signs all assertions and shards if set to true
+* `SignAssertions`: Signs all assertions if set to true
+* `SignShards`: Signs all shards if set to true
+* `OutputFilePath`: If set, a zonefile with the signed sections is generated and
+  stored at the provided path
+* `DoPublish`: Sends the signed sections to all authoritative rainsd servers if
+  it is set to true
+* ``:
+
+## Issues
+
+TODO how to handle/spread shards

--- a/yacc/makefile
+++ b/yacc/makefile
@@ -1,0 +1,9 @@
+all:
+	goyacc -p "ZFP" zonefileParser.y
+	go build -o zonefileParser y.go
+	./zonefileParser
+
+clean:
+	rm y.go
+	rm y.output
+	rm zonefileParser

--- a/yacc/zonefile.txt
+++ b/yacc/zonefile.txt
@@ -1,0 +1,32 @@
+:Z: ch. . [
+                :S: a b [
+                        :A: ch  [ :name: a [ :ip4: :ip6: ] ]
+                        :A: ch  [ :ip4: 192.168.1.10 ]
+                        :A: ethz [ 
+                                :ip6:      2001:0db8:85a3:0000:0000:8a2e:0370:7334
+                                :ip6:      129.132.128.139
+                        ]
+                        :A: ch  [ :deleg: :ed25519: 5
+                        e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
+                        ]
+                        :A: ch  [ :nameset: Hello How are you ]
+                        :A: ch  [ :cert: :tls: :endEntity: :sha256: e28b1bd3a73882b198dfe4f0fa954c ]
+                        :A: ch  [ :srv: dns 53 0 ]
+                        :A: ch  [ :regr: registrar text ]
+                        :A: ch  [ :regt: registrant info ]
+                        :A: ch  [ :infra: :ed25519: 5
+                        e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
+                        ]
+                        :A: ch  [ :extra: :ed25519: 5
+                        e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
+                        ]
+                        :A: ch  [ :next: :ed25519: 5
+                        e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
+                        100000 20000000 ]
+         ]
+         :A: ch  [ :ip4: 192.168.1.10 ]
+         :A: ch  [ :ip4: 192.168.1.10 ]
+         :S: c d [ ]
+] ( :sig: :ed25519: :rains: 1 2000 5000 )
+:Z: com. . [ ]
+:A: ethz ch. . [ :ip4: 192.168.1.10 ]

--- a/yacc/zonefile.txt
+++ b/yacc/zonefile.txt
@@ -1,32 +1,33 @@
-:Z: ch. . [
-                :S: a b [
-                        :A: ch  [ :name: a [ :ip4: :ip6: ] ]
-                        :A: ch  [ :ip4: 192.168.1.10 ]
-                        :A: ethz [ 
+:Z: com. . [
+                :S: a f [
+                        :A: example  [ :name: example2 [ :ip4: :ip6: ] ]
+                        :A: example [ 
                                 :ip6:      2001:0db8:85a3:0000:0000:8a2e:0370:7334
-                                :ip6:      129.132.128.139
+                                :ip6:      2001:db8::
                         ]
-                        :A: ch  [ :deleg: :ed25519: 5
+                        :A: example  [ :ip4: 192.168.1.10 ]
+                        :A: example  [ :redir: ns.example.com ]
+                        :A: example  [ :deleg: :ed25519: 1
                         e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
                         ]
-                        :A: ch  [ :nameset: Hello How are you ]
-                        :A: ch  [ :cert: :tls: :endEntity: :sha256: e28b1bd3a73882b198dfe4f0fa954c ]
-                        :A: ch  [ :srv: dns 53 0 ]
-                        :A: ch  [ :regr: registrar text ]
-                        :A: ch  [ :regt: registrant info ]
-                        :A: ch  [ :infra: :ed25519: 5
+                        :A: example  [ :nameset: * ]
+                        :A: example  [ :cert: :tls: :endEntity: :sha256: e28b1bd3a73882b198dfe4f0fa954c ]
+                        :A: ns.example  [ :srv: rains 5012 5 ]
+                        :A: example  [ :regr: Some registrar and his info ]
+                        :A: example  [ :regt: John Doe  ]
+                        :A: example  [ :infra: :ed25519: 2
                         e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
                         ]
-                        :A: ch  [ :extra: :ed25519: 5
+                        :A: example  [ :extra: :ed25519: 1
                         e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
                         ]
-                        :A: ch  [ :next: :ed25519: 5
+                        :A: example  [ :next: :ed25519: 3
                         e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
                         100000 20000000 ]
          ]
-         :A: ch  [ :ip4: 192.168.1.10 ]
-         :A: ch  [ :ip4: 192.168.1.10 ]
+         :A: example  [ :ip4: 192.0.2.0 ]
+         :A: example  [ :ip4: 192.0.2.1 ]
          :S: c d [ ]
-] ( :sig: :ed25519: :rains: 1 2000 5000 )
-:Z: com. . [ ]
-:A: ethz ch. . [ :ip4: 192.168.1.10 ]
+] ( :sig: :ed25519: :rains: 1 1534451766 1535451766 )
+:Z: abc. . [ ]
+:A: example com. . [ :ip4: 192.0.2.0 ]

--- a/yacc/zonefileParser.y
+++ b/yacc/zonefileParser.y
@@ -8,7 +8,7 @@
 
 package main
 
-import (  
+import (
 	"bufio"
     "bytes"
     "encoding/hex"
@@ -22,13 +22,15 @@ import (
     "golang.org/x/crypto/ed25519"
 )
 
-//AddSigs adds signatures to section
+//AddSigs adds signatures to section.
 func AddSigs(section rainslib.MessageSectionWithSigForward, signatures []rainslib.Signature) {
     for _, sig := range signatures {
         section.AddSig(sig)
     }
 }
 
+//DecodePublicKeyID converts the keyphase string into an integer and returns a 
+//PublicKeyID struct with the provided keyphase and default algorithm/keyspace.
 func DecodePublicKeyID(keyphase string) (rainslib.PublicKeyID, error) {
     phase, err := strconv.Atoi(keyphase)
 	if err != nil {
@@ -41,8 +43,10 @@ func DecodePublicKeyID(keyphase string) (rainslib.PublicKeyID, error) {
 	}, nil
 }
 
+//DecodeEd25519SignatureData decodes an ed25519 signature which is hex encoded
+//in input and returns it.
 func DecodeEd25519SignatureData(input string) (interface{}, error) {
-    return "notYetImplemented", nil
+    return nil, errors.New("notYetImplemented")
 }
 
 // DecodeEd25519PublicKeyData returns the publicKey or an error in case
@@ -57,16 +61,17 @@ func DecodeEd25519PublicKeyData(pkeyInput string, keyphase string) (rainslib.Pub
 		return rainslib.PublicKey{}, err
 	}
 	if len(pKey) == 32 {
-		publicKey := rainslib.PublicKey{Key: ed25519.PublicKey(pKey), PublicKeyID: publicKeyID}
-		return publicKey, nil
+		return rainslib.PublicKey{Key: ed25519.PublicKey(pKey), PublicKeyID: publicKeyID}, nil
 	}
 	return rainslib.PublicKey{}, fmt.Errorf("wrong public key length: got %d, want: 32", len(pKey))
 }
 
+//DecodeCertificate decodes the provided certificate which is hex encoded and
+//returns it.
 func DecodeCertificate(ptype rainslib.ProtocolType, usage rainslib.CertificateUsage, 
-    hashAlgo rainslib.HashAlgorithmType, certificat string) (rainslib.CertificateObject,
+    hashAlgo rainslib.HashAlgorithmType, certificate string) (rainslib.CertificateObject,
 error) {
-    data, err := hex.DecodeString(certificat)
+    data, err := hex.DecodeString(certificate)
     if err != nil {
         return rainslib.CertificateObject{}, err
     }
@@ -78,6 +83,8 @@ error) {
     }, nil
 }
 
+//DecodeSrv parses portString and priorityString to int64 and returns a
+//serviceInfo object.
 func DecodeSrv(name, portString, priorityString string) (rainslib.ServiceInfo, error) {
     port, err := strconv.Atoi(portString)
     if  err != nil || port < 0 || port > 65535 {
@@ -94,6 +101,7 @@ func DecodeSrv(name, portString, priorityString string) (rainslib.ServiceInfo, e
     }, nil
 }
 
+//DecodeValidity parses validSince and validUntil to int64 and returns them.
 func DecodeValidity(validSince, validUntil string) (int64, int64, error) {
     vsince, err := strconv.ParseInt(validSince, 10, 64)
     if  err != nil || vsince < 0 {
@@ -287,7 +295,7 @@ assertion       : assertionBody
                     AddSigs($1,$2)
                     $$ = $1
                 }
-    
+
 assertionBody   : assertionType ID lBracket objects rBracket
                 {
                     $$ = &rainslib.AssertionSection{
@@ -598,7 +606,7 @@ extra           : extraBody
 
 extraBody       : extraType ed25519Type ID ID
                 {   //TODO CFE as of now there is only the rains key space. There will
-                    //be additional rules in case there are new key spaces 
+                    //be additional rules in case there are new key spaces
                     pkey, err := DecodeEd25519PublicKeyData($4, $3)
                     if  err != nil {
                         log.Error("semantic error:", "DecodeEd25519PublicKeyData", err)
@@ -691,7 +699,7 @@ annotationBody  : signature
 
 signature       : signatureMeta
                 | signatureMeta ID
-                {   
+                {
                     data, err := DecodeEd25519SignatureData($2)
                     if  err != nil {
                         log.Error("semantic error:", "DecodeEd25519SignatureData", err)
@@ -723,7 +731,7 @@ signatureMeta   : sigType ed25519Type rains ID ID ID
 const eof = 0
 
 type ZFPLex struct {
-	lines       [][]string
+    lines       [][]string
     lineNr      int
     linePos     int
 }
@@ -751,38 +759,38 @@ func (l *ZFPLex) Lex(lval *ZFPSymType) int {
     }
     //return token
     switch word {
-	case ":A:" :
+    case ":A:" :
         return assertionType
     case ":S:" :
         return shardType
     case ":Z:" :
         return zoneType
     case ":name:" :
-		return nameType
-	case ":ip6:" :
-		return ip6Type
-	case ":ip4:" :
-		return ip4Type
-	case ":redir:" :
-		return redirType
-	case ":deleg:" :
-		return delegType
-	case ":nameset:" :
-		return namesetType
-	case ":cert:" :
-		return certType
-	case ":srv:" :
-		return srvType
-	case ":regr:" :
-		return regrType
-	case ":regt:" :
-		return regtType
-	case ":infra:" :
-		return infraType
-	case ":extra:" :
-		return extraType
-	case ":next:" :
-		return nextType
+        return nameType
+    case ":ip6:" :
+        return ip6Type
+    case ":ip4:" :
+        return ip4Type
+    case ":redir:" :
+        return redirType
+    case ":deleg:" :
+        return delegType
+    case ":nameset:" :
+        return namesetType
+    case ":cert:" :
+        return certType
+    case ":srv:" :
+        return srvType
+    case ":regr:" :
+        return regrType
+    case ":regt:" :
+        return regtType
+    case ":infra:" :
+        return infraType
+    case ":extra:" :
+        return extraType
+    case ":next:" :
+        return nextType
     case ":sig:" :
         return sigType
     case ":ed25519:" :
@@ -817,10 +825,10 @@ func (l *ZFPLex) Lex(lval *ZFPSymType) int {
         return lParenthesis
     case ")" :
         return rParenthesis
-	default :
+    default :
         lval.str = word
         return ID
-	}
+    }
 }
 
 // The parser calls this method on a parse error.
@@ -831,10 +839,10 @@ func (l *ZFPLex) Error(s string) {
     }
     if l.linePos == 0 && l.lineNr == 0 {
         log.Error("syntax error:", "lineNr", 1, "wordNr", 0,
-	    "token", "noToken")
+        "token", "noToken")
     } else {
-	    log.Error("syntax error:", "lineNr", l.lineNr+1, "wordNr", l.linePos,
-	    "token", l.lines[l.lineNr][l.linePos-1])
+        log.Error("syntax error:", "lineNr", l.lineNr+1, "wordNr", l.linePos,
+        "token", l.lines[l.lineNr][l.linePos-1])
     }
 }
 
@@ -855,7 +863,7 @@ func removeComments(scanner *bufio.Scanner) [][]string {
         inputWithoutComments := strings.Split(scanner.Text(), ";")[0]
         var words []string
         ws := bufio.NewScanner(strings.NewReader(inputWithoutComments))
-	    ws.Split(bufio.ScanWords)
+        ws.Split(bufio.ScanWords)
         for ws.Scan() {
             words = append(words, ws.Text())
         } 

--- a/yacc/zonefileParser.y
+++ b/yacc/zonefileParser.y
@@ -1,0 +1,865 @@
+// To build it:
+// goyacc -p "ZFP" zonefileParser.y (produces y.go)
+// go build -o zonefileParser y.go
+// run ./zonefileParser, the zonefile must be placed in the same directoy and
+// must be called zonefile.txt
+
+%{
+
+package main
+
+import (  
+	"bufio"
+    "bytes"
+    "encoding/hex"
+    "errors"
+	"fmt"
+	"io/ioutil"
+    "strconv"
+    "strings"
+    log "github.com/inconshreveable/log15"
+    "github.com/netsec-ethz/rains/rainslib"
+    "golang.org/x/crypto/ed25519"
+)
+
+//AddSigs adds signatures to section
+func AddSigs(section rainslib.MessageSectionWithSigForward, signatures []rainslib.Signature) {
+    for _, sig := range signatures {
+        section.AddSig(sig)
+    }
+}
+
+func DecodePublicKeyID(keyphase string) (rainslib.PublicKeyID, error) {
+    phase, err := strconv.Atoi(keyphase)
+	if err != nil {
+		return rainslib.PublicKeyID{}, errors.New("keyphase is not a number")
+	}
+    return rainslib.PublicKeyID{
+		Algorithm: rainslib.Ed25519,
+        KeyPhase:  phase,
+		KeySpace:  rainslib.RainsKeySpace,
+	}, nil
+}
+
+func DecodeEd25519SignatureData(input string) (interface{}, error) {
+    return "notYetImplemented", nil
+}
+
+// DecodeEd25519PublicKeyData returns the publicKey or an error in case
+// pkeyInput is malformed i.e. it is not in zone file format.
+func DecodeEd25519PublicKeyData(pkeyInput string, keyphase string) (rainslib.PublicKey, error) {
+	publicKeyID, err := DecodePublicKeyID(keyphase)
+    if err != nil {
+		return rainslib.PublicKey{}, err
+	}
+	pKey, err := hex.DecodeString(pkeyInput)
+	if err != nil {
+		return rainslib.PublicKey{}, err
+	}
+	if len(pKey) == 32 {
+		publicKey := rainslib.PublicKey{Key: ed25519.PublicKey(pKey), PublicKeyID: publicKeyID}
+		return publicKey, nil
+	}
+	return rainslib.PublicKey{}, fmt.Errorf("wrong public key length: got %d, want: 32", len(pKey))
+}
+
+func DecodeCertificate(ptype rainslib.ProtocolType, usage rainslib.CertificateUsage, 
+    hashAlgo rainslib.HashAlgorithmType, certificat string) (rainslib.CertificateObject,
+error) {
+    data, err := hex.DecodeString(certificat)
+    if err != nil {
+        return rainslib.CertificateObject{}, err
+    }
+    return rainslib.CertificateObject{
+        Type:     ptype,
+        Usage:    usage,
+        HashAlgo: hashAlgo,
+        Data:     data,
+    }, nil
+}
+
+func DecodeSrv(name, portString, priorityString string) (rainslib.ServiceInfo, error) {
+    port, err := strconv.Atoi(portString)
+    if  err != nil || port < 0 || port > 65535 {
+        return rainslib.ServiceInfo{}, errors.New("Port is not a number or out of range")
+    }
+    priority, err := strconv.Atoi(priorityString)
+    if  err != nil || port < 0 {
+        return rainslib.ServiceInfo{}, errors.New("Priority is not a number or negative")
+    }
+    return rainslib.ServiceInfo {
+        Name: name,
+        Port: uint16(port),
+        Priority: uint(priority),
+    }, nil
+}
+
+func DecodeValidity(validSince, validUntil string) (int64, int64, error) {
+    vsince, err := strconv.ParseInt(validSince, 10, 64)
+    if  err != nil || vsince < 0 {
+        return 0,0, errors.New("validSince is not a number or negative")
+    }
+    vuntil, err := strconv.ParseInt(validUntil, 10, 64)
+    if  err != nil || vuntil < 0 {
+        return 0,0, errors.New("validUntil is not a number or negative")
+    }
+    return vsince, vuntil, nil
+}
+
+%}
+
+// fields inside this union end up as the fields in a structure known
+// as ${PREFIX}SymType, of which a reference is passed to the lexer.
+%union{
+    str             string
+    assertion       *rainslib.AssertionSection
+    assertions      []*rainslib.AssertionSection
+    shard           *rainslib.ShardSection
+    zone            *rainslib.ZoneSection
+    sections        []rainslib.MessageSectionWithSigForward
+    objects         []rainslib.Object
+    object          rainslib.Object
+    objectTypes     []rainslib.ObjectType
+    objectType      rainslib.ObjectType
+    signatures      []rainslib.Signature
+    signature       rainslib.Signature
+    shardRange      []string
+    publicKey       rainslib.PublicKey
+    protocolType    rainslib.ProtocolType
+    certUsage       rainslib.CertificateUsage
+    hashType        rainslib.HashAlgorithmType
+}
+
+// any non-terminal which returns a value needs a type, which must be a field 
+// name in the above union struct
+%type <zone>            zone zoneBody
+%type <sections>        zoneContent sections
+%type <shard>           shard shardBody
+%type <shardRange>      shardRange
+%type <assertions>      shardContent
+%type <assertion>       assertion assertionBody
+%type <objects>         objects name ip4 ip6 redir deleg nameset cert
+%type <objects>         srv regr regt infra extra next
+%type <object>          nameBody ip4Body ip6Body redirBody delegBody namesetBody certBody
+%type <object>          srvBody regrBody regtBody infraBody extraBody nextBody
+%type <objectTypes>     oTypes
+%type <objectType>      oType
+%type <signatures>      annotation annotationBody
+%type <signature>       signature signatureMeta
+%type <str>             freeText
+%type <protocolType>    protocolType
+%type <certUsage>       certUsage
+%type <hashType>        hashType
+
+// Terminals
+%token <str> ID
+// Section types
+%token assertionType shardType zoneType
+// Object types
+%token nameType ip4Type ip6Type redirType delegType namesetType certType
+%token srvType regrType regtType infraType extraType nextType
+// Annotation types
+%token sigType 
+// Signature algorithm types
+%token ed25519Type
+// Certificate types
+%token unspecified tls trustAnchor endEntity 
+// Hash algorithm types
+%token noHash sha256 sha384 sha512
+// Key spaces
+%token rains
+// Special shard range markers
+%token rangeBegin rangeEnd
+// Special
+%token lBracket rBracket lParenthesis rParenthesis
+
+%% /* Grammer rules  */
+
+top             : sections
+                {
+                    fmt.Print("\n")
+                    for _,s := range $1 {
+                        fmt.Printf("%s\n", s.String())
+                    }
+                }
+
+sections        : /* empty */
+                {
+                    $$ = nil
+                }
+                | sections assertion
+                {
+                    $$ = append($1, $2)
+                }
+                | sections shard
+                {
+                    $$ = append($1, $2)
+                }
+                | sections zone
+                {
+                    $$ = append($1, $2)
+                }
+
+zone            : zoneBody
+                | zoneBody annotation
+                {
+                    AddSigs($1,$2)
+                    $$ = $1
+                }
+
+zoneBody        : zoneType ID ID lBracket zoneContent rBracket
+                {
+                    $$ = &rainslib.ZoneSection{
+                        SubjectZone: $2, 
+                        Context: $3,
+                        Content: $5,    
+                    }
+                }
+
+zoneContent     : /* empty */
+                {
+                    $$ = nil
+                }
+                | zoneContent assertion
+                {
+                    $$ = append($1, $2)
+                }
+                | zoneContent shard
+                {
+                    $$ = append($1, $2)
+                }
+
+shard           : shardBody
+                | shardBody annotation
+                {
+                    AddSigs($1,$2)
+                    $$ = $1
+                }
+
+shardBody       : shardType ID ID shardRange lBracket shardContent rBracket
+                {
+                    $$ = &rainslib.ShardSection{
+                        SubjectZone: $2, 
+                        Context: $3,
+                        RangeFrom: $4[0],
+                        RangeTo: $4[1],
+                        Content: $6,
+                    }
+                }
+                | shardType shardRange lBracket shardContent rBracket
+                {
+                    $$ = &rainslib.ShardSection{
+                        RangeFrom: $2[0],
+                        RangeTo: $2[1],
+                        Content: $4,
+                    }
+                }
+
+shardRange      : ID ID
+                {
+                    $$ = []string{$1, $2}
+                }
+                | rangeBegin ID
+                {
+                    $$ = []string{"<", $2}
+                }
+                | ID rangeEnd
+                {
+                    $$ = []string{$1, ">"}
+                }
+                | rangeBegin rangeEnd
+                {
+                    $$ = []string{"<", ">"}
+                }
+
+shardContent :  /* empty */
+                {
+                    $$ = nil
+                }
+                | shardContent assertion
+                {
+                    $$ = append($1,$2)
+                }
+
+assertion       : assertionBody
+                | assertionBody annotation
+                {
+                    AddSigs($1,$2)
+                    $$ = $1
+                }
+    
+assertionBody   : assertionType ID lBracket objects rBracket
+                {
+                    $$ = &rainslib.AssertionSection{
+                        SubjectName: $2,
+                        Content: $4,
+                    }
+                }
+                | assertionType ID ID ID lBracket objects rBracket
+                {
+                    $$ = &rainslib.AssertionSection{
+                        SubjectZone: $2, 
+                        Context: $3,
+                        SubjectName: $4,
+                        Content: $6,
+                    }
+                }
+
+objects          : name
+                | ip6
+                | ip4
+                | redir
+                | deleg
+                | nameset
+                | cert
+                | srv
+                | regr
+                | regt
+                | infra
+                | extra
+                | next
+
+name            : nameBody
+                {
+                    $$ = []rainslib.Object{$1}
+                }
+                | name nameBody
+                {
+                    $$ = append($1,$2)
+                }
+
+nameBody        : nameType ID lBracket oTypes rBracket
+                {
+                    $$ = rainslib.Object{
+                        Type: rainslib.OTName,
+                        Value: rainslib.NameObject{
+                            Name: $2,
+                            Types: $4,
+                        },
+                    }
+                }
+
+oTypes          : oType
+                {
+                    $$ = []rainslib.ObjectType{$1}
+                }
+                | oTypes oType
+                {
+                    $$ = append($1,$2)
+                }
+
+oType           : nameType
+                {
+                    $$ = rainslib.OTName
+                }
+                | ip4Type
+                {
+                    $$ = rainslib.OTIP4Addr
+                }
+                | ip6Type
+                {
+                    $$ = rainslib.OTIP6Addr
+                }
+                | redirType
+                {
+                    $$ = rainslib.OTRedirection
+                }
+                | delegType
+                {
+                    $$ = rainslib.OTDelegation
+                }
+                | namesetType
+                {
+                    $$ = rainslib.OTNameset
+                }
+                | certType
+                {
+                    $$ = rainslib.OTCertInfo
+                }
+                | srvType
+                {
+                    $$ = rainslib.OTServiceInfo
+                }
+                | regrType
+                {
+                    $$ = rainslib.OTRegistrar
+                }
+                | regtType
+                {
+                    $$ = rainslib.OTRegistrant
+                }
+                | infraType
+                {
+                    $$ = rainslib.OTInfraKey
+                }
+                | extraType
+                {
+                    $$ = rainslib.OTExtraKey
+                }
+                | nextType
+                {
+                    $$ = rainslib.OTNextKey
+                }
+
+ip6             : ip6Body
+                {
+                    $$ = []rainslib.Object{$1}
+                }
+                | ip6 ip6Body
+                {
+                    $$ = append($1,$2)
+                }
+
+ip6Body         : ip6Type ID
+                {
+                    $$ = rainslib.Object{
+                        Type: rainslib.OTIP6Addr,
+                        Value: $2,
+                    }
+                }
+
+ip4             : ip4Body
+                {
+                    $$ = []rainslib.Object{$1}
+                }
+                | ip4 ip4Body
+                {
+                    $$ = append($1,$2)
+                }
+
+ip4Body         : ip4Type ID
+                {
+                    $$ = rainslib.Object{
+                        Type: rainslib.OTIP4Addr,
+                        Value: $2,
+                    }
+                }
+
+redir             : redirBody
+                {
+                    $$ = []rainslib.Object{$1}
+                }
+                | redir redirBody
+                {
+                    $$ = append($1,$2)
+                }
+
+redirBody       : redirType ID
+                {
+                    $$ = rainslib.Object{
+                        Type: rainslib.OTRedirection,
+                        Value: $2,
+                    }
+                }
+
+deleg           : delegBody
+                {
+                    $$ = []rainslib.Object{$1}
+                }
+                | deleg delegBody
+                {
+                    $$ = append($1,$2)
+                }
+
+delegBody       : delegType ed25519Type ID ID
+                {
+                    pkey, err := DecodeEd25519PublicKeyData($4, $3)
+                    if  err != nil {
+                        log.Error("semantic error:", "DecodeEd25519PublicKeyData", err)
+                    }
+                    $$ = rainslib.Object{
+                        Type: rainslib.OTDelegation,
+                        Value: pkey,
+                    }
+                }
+
+nameset         : namesetBody
+                {
+                    $$ = []rainslib.Object{$1}
+                }
+                | nameset namesetBody
+                {
+                    $$ = append($1,$2)
+                }
+
+namesetBody     : namesetType freeText
+                {
+                    $$ = rainslib.Object{
+                        Type: rainslib.OTNameset,
+                        Value: $2,
+                    }
+                }
+
+cert            : certBody
+                {
+                    $$ = []rainslib.Object{$1}
+                }
+                | cert certBody
+                {
+                    $$ = append($1,$2)
+                }
+
+certBody :      certType protocolType certUsage hashType ID
+                {
+                    cert, err := DecodeCertificate($2,$3,$4,$5)
+                    if err != nil {
+                        log.Error("semantic error:", "Decode certificate", err)
+                    }
+                    $$ = rainslib.Object{
+                        Type: rainslib.OTCertInfo,
+                        Value: cert,
+                    }
+                }
+
+srv             : srvBody
+                {
+                    $$ = []rainslib.Object{$1}
+                }
+                | srv srvBody
+                {
+                    $$ = append($1,$2)
+                }
+
+srvBody         : srvType ID ID ID
+                {
+                    srv, err := DecodeSrv($2,$3,$4)
+                    if err != nil {
+                        log.Error("semantic error:", "error", err)
+                    }
+                    $$ = rainslib.Object{
+                        Type: rainslib.OTServiceInfo,
+                        Value: srv,
+                    }
+                }
+
+regr            : regrBody
+                {
+                    $$ = []rainslib.Object{$1}
+                }
+                | regr regrBody
+                {
+                    $$ = append($1,$2)
+                }
+
+regrBody        : regrType freeText
+                {
+                    $$ = rainslib.Object{
+                        Type: rainslib.OTRegistrar,
+                        Value: $2,
+                    }
+                }
+
+regt            : regtBody
+                {
+                    $$ = []rainslib.Object{$1}
+                }
+                | regt regtBody
+                {
+                    $$ = append($1,$2)
+                }
+
+regtBody        : regtType freeText
+                {
+                    $$ = rainslib.Object{
+                        Type: rainslib.OTRegistrant,
+                        Value: $2,
+                    }
+                }
+
+infra           : infraBody
+                {
+                    $$ = []rainslib.Object{$1}
+                }
+                | infra infraBody
+                {
+                    $$ = append($1,$2)
+                }
+
+infraBody       : infraType ed25519Type ID ID
+                {
+                    pkey, err := DecodeEd25519PublicKeyData($4, $3)
+                    if  err != nil {
+                        log.Error("semantic error:", "DecodeEd25519PublicKeyData", err)
+                    }
+                    $$ = rainslib.Object{
+                        Type: rainslib.OTInfraKey,
+                        Value: pkey,
+                    }
+                }
+
+extra           : extraBody
+                {
+                    $$ = []rainslib.Object{$1}
+                }
+                | extra extraBody
+                {
+                    $$ = append($1,$2)
+                }
+
+extraBody       : extraType ed25519Type ID ID
+                {   //TODO CFE as of now there is only the rains key space. There will
+                    //be additional rules in case there are new key spaces 
+                    pkey, err := DecodeEd25519PublicKeyData($4, $3)
+                    if  err != nil {
+                        log.Error("semantic error:", "DecodeEd25519PublicKeyData", err)
+                    }
+                    $$ = rainslib.Object{
+                        Type: rainslib.OTExtraKey,
+                        Value: pkey,
+                    }
+                }
+
+next            : nextBody
+                {
+                    $$ = []rainslib.Object{$1}
+                }
+                | next nextBody
+                {
+                    $$ = append($1,$2)
+                }
+
+nextBody        : nextType ed25519Type ID ID ID ID
+                {
+                    pkey, err := DecodeEd25519PublicKeyData($4, $3)
+                    if  err != nil {
+                        log.Error("semantic error:", "DecodeEd25519PublicKeyData", err)
+                    }
+                    pkey.ValidSince, pkey.ValidUntil, err = DecodeValidity($5,$6)
+                    if  err != nil {
+                        log.Error("semantic error:", "error", err)
+                    }
+                    $$ = rainslib.Object{
+                        Type: rainslib.OTNextKey,
+                        Value: pkey,
+                    }
+                }
+
+protocolType    : unspecified
+                {
+                    $$ = rainslib.PTUnspecified
+                }
+                | tls
+                {
+                    $$ = rainslib.PTTLS
+                }
+
+certUsage       : trustAnchor
+                {
+                    $$ = rainslib.CUTrustAnchor
+                }
+                | endEntity
+                {
+                    $$ = rainslib.CUEndEntity
+                }
+
+hashType        : noHash
+                {
+                    $$ = rainslib.NoHashAlgo
+                }
+                | sha256
+                {
+                    $$ = rainslib.Sha256
+                }
+                | sha384
+                {
+                    $$ = rainslib.Sha384
+                }
+                | sha512
+                {
+                    $$ = rainslib.Sha512
+                }
+
+freeText        : ID
+                | freeText ID
+                {
+                    $$ = $1 + " " + $2
+                }
+
+annotation      : lParenthesis annotationBody rParenthesis
+                {
+                    $$ = $2
+                }
+
+annotationBody  : signature
+                {
+                    $$ = []rainslib.Signature{$1}
+                }
+                | annotationBody signature
+                {
+                    $$ = append($1, $2)
+                }
+
+signature       : signatureMeta
+                | signatureMeta ID
+                {   
+                    data, err := DecodeEd25519SignatureData($2)
+                    if  err != nil {
+                        log.Error("semantic error:", "DecodeEd25519SignatureData", err)
+                    }
+                    $1.Data = data
+                    $$ = $1
+                }
+
+signatureMeta   : sigType ed25519Type rains ID ID ID
+                {
+                    publicKeyID, err := DecodePublicKeyID($4)
+                    if  err != nil {
+                        log.Error("semantic error:", "DecodePublicKeyID", err)
+                    }
+                    validSince, validUntil, err := DecodeValidity($5,$6)
+                    if  err != nil {
+                        log.Error("semantic error:", "DecodeValidity", err)
+                    }
+                    $$ = rainslib.Signature{
+                        PublicKeyID: publicKeyID,
+                        ValidSince: validSince,
+                        ValidUntil: validUntil,
+                    }
+                }
+
+%%      /*  Lexer  */
+
+// The parser expects the lexer to return 0 on EOF.
+const eof = 0
+
+type ZFPLex struct {
+	lines       [][]string
+    lineNr      int
+    linePos     int
+}
+
+func (l *ZFPLex) Lex(lval *ZFPSymType) int {
+    if l.lineNr == len(l.lines) {
+        return eof
+    }
+    //read data and skip empty lines
+    line := l.lines[l.lineNr]
+    for len(line) == 0 {
+        l.lineNr++
+        if l.lineNr == len(l.lines) {
+            return eof
+        }
+        line = l.lines[l.lineNr]
+    }
+    word := line[l.linePos]
+    //update state
+    if l.linePos == len(line)-1 {
+        l.lineNr++
+        l.linePos = 0
+    } else {
+        l.linePos++
+    }
+    //return token
+    switch word {
+	case ":A:" :
+        return assertionType
+    case ":S:" :
+        return shardType
+    case ":Z:" :
+        return zoneType
+    case ":name:" :
+		return nameType
+	case ":ip6:" :
+		return ip6Type
+	case ":ip4:" :
+		return ip4Type
+	case ":redir:" :
+		return redirType
+	case ":deleg:" :
+		return delegType
+	case ":nameset:" :
+		return namesetType
+	case ":cert:" :
+		return certType
+	case ":srv:" :
+		return srvType
+	case ":regr:" :
+		return regrType
+	case ":regt:" :
+		return regtType
+	case ":infra:" :
+		return infraType
+	case ":extra:" :
+		return extraType
+	case ":next:" :
+		return nextType
+    case ":sig:" :
+        return sigType
+    case ":ed25519:" :
+        return ed25519Type
+    case ":unspecified:" :
+        return unspecified
+    case ":tls:" :
+        return tls
+    case ":trustAnchor:" :
+        return trustAnchor
+    case ":endEntity:" :
+        return endEntity
+    case ":noHash:" :
+        return noHash
+    case ":sha256:" :
+        return sha256
+    case ":sha384:" :
+        return sha384
+    case ":sha512:" :
+        return sha512
+    case ":rains:" :
+        return rains
+    case "<" :
+        return rangeBegin
+    case ">" :
+        return rangeEnd
+    case "[" :
+        return lBracket
+    case "]" :
+        return rBracket
+    case "(" :
+        return lParenthesis
+    case ")" :
+        return rParenthesis
+	default :
+        lval.str = word
+        return ID
+	}
+}
+
+// The parser calls this method on a parse error.
+func (l *ZFPLex) Error(s string) {
+    for l.linePos == 0 && l.lineNr > 0 {
+        l.lineNr--
+        l.linePos = len(l.lines[l.lineNr])
+    }
+    if l.linePos == 0 && l.lineNr == 0 {
+        log.Error("syntax error:", "lineNr", 1, "wordNr", 0,
+	    "token", "noToken")
+    } else {
+	    log.Error("syntax error:", "lineNr", l.lineNr+1, "wordNr", l.linePos,
+	    "token", l.lines[l.lineNr][l.linePos-1])
+    }
+}
+
+func main() {
+    file, err := ioutil.ReadFile("zonefile.txt")
+    if err != nil {
+        log.Error(err.Error())
+        return
+    }
+    lines := removeComments(bufio.NewScanner(bytes.NewReader(file)))
+    log.Debug("Preprocessed input", "data", lines)
+    ZFPParse(&ZFPLex{lines: lines})
+}
+
+func removeComments(scanner *bufio.Scanner) [][]string {
+    var lines [][]string
+    for scanner.Scan() {
+        inputWithoutComments := strings.Split(scanner.Text(), ";")[0]
+        var words []string
+        ws := bufio.NewScanner(strings.NewReader(inputWithoutComments))
+	    ws.Split(bufio.ScanWords)
+        for ws.Scan() {
+            words = append(words, ws.Text())
+        } 
+        lines = append(lines, words)
+    }
+    return lines
+}


### PR DESCRIPTION
design-zone-manager.md: Design proposal about how a zone authority can manage its zone.
design-zonefile-format.md: Specification of the zone file format
Yacc: This folder contains the implementation of a zone file parser according to the zone file format specification. The parser code can be generated by calling the make file which also runs the parser on the zonefile.txt file in the same directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/rains/91)
<!-- Reviewable:end -->
