### PR TITLE
Implement SCION functionality in rainsd.

### DIFF
--- a/internal/pkg/connection/type_jsonenums.go
+++ b/internal/pkg/connection/type_jsonenums.go
@@ -9,13 +9,15 @@ import (
 
 var (
 	_TypeNameToValue = map[string]Type{
-		"Chan": Chan,
-		"TCP":  TCP,
+		"Chan":  Chan,
+		"TCP":   TCP,
+		"SCION": SCION,
 	}
 
 	_TypeValueToName = map[Type]string{
-		Chan: "Chan",
-		TCP:  "TCP",
+		Chan:  "Chan",
+		TCP:   "TCP",
+		SCION: "SCION",
 	}
 )
 
@@ -23,8 +25,9 @@ func init() {
 	var v Type
 	if _, ok := interface{}(v).(fmt.Stringer); ok {
 		_TypeNameToValue = map[string]Type{
-			interface{}(Chan).(fmt.Stringer).String(): Chan,
-			interface{}(TCP).(fmt.Stringer).String():  TCP,
+			interface{}(Chan).(fmt.Stringer).String():  Chan,
+			interface{}(TCP).(fmt.Stringer).String():   TCP,
+			interface{}(SCION).(fmt.Stringer).String(): SCION,
 		}
 	}
 }

--- a/internal/pkg/connection/type_string.go
+++ b/internal/pkg/connection/type_string.go
@@ -4,9 +4,9 @@ package connection
 
 import "strconv"
 
-const _Type_name = "ChanTCP"
+const _Type_name = "ChanTCPSCION"
 
-var _Type_index = [...]uint8{0, 4, 7}
+var _Type_index = [...]uint8{0, 4, 7, 12}
 
 func (i Type) String() string {
 	if i < 0 || i >= Type(len(_Type_index)-1) {

--- a/internal/pkg/rainsd/serverInfo.go
+++ b/internal/pkg/rainsd/serverInfo.go
@@ -27,6 +27,10 @@ type rainsdConfig struct {
 	TLSCertificateFile string
 	TLSPrivateKeyFile  string
 
+	// SCION specific settings
+	DispatcherSock string
+	SciondSock     string
+
 	//inbox
 	MaxMsgByteLength        uint
 	PrioBufferSize          uint

--- a/internal/pkg/rainsd/switchboard.go
+++ b/internal/pkg/rainsd/switchboard.go
@@ -19,29 +19,53 @@ import (
 	"github.com/netsec-ethz/rains/internal/pkg/connection"
 	"github.com/netsec-ethz/rains/internal/pkg/message"
 	"github.com/netsec-ethz/rains/internal/pkg/query"
+	"github.com/scionproto/scion/go/lib/snet"
 )
 
 //sendTo sends message to the specified receiver.
 func (s *Server) sendTo(msg message.Message, receiver net.Addr, retries,
 	backoffMilliSeconds int) (err error) {
+	// SCION is a special case because it is operating on a connectionless protocol so we
+	// just send out the data on the contained connection.
+	if sc, ok := receiver.(*connection.SCIONAddr); ok {
+		conn := sc.Underlying
+		if conn == nil {
+			return errors.New("underlying scion connection was nil")
+		}
+		encoding := new(bytes.Buffer)
+		if err := cbor.NewWriter(encoding).Marshal(&msg); err != nil {
+			return fmt.Errorf("failed to marshal message to conn: %v", err)
+		}
+		if _, err := conn.Write(encoding.Bytes()); err != nil {
+			log.Warn("Was not able to send encoded message")
+			return fmt.Errorf("unable to send encoded message: %v", err)
+		}
+		return nil
+	}
 	conns, ok := s.caches.ConnCache.GetConnection(receiver)
 	if !ok {
-		conn, err := createConnection(receiver, s.config.KeepAlivePeriod, s.certPool)
-		//add connection to cache
-		conns = append(conns, conn)
-		if err != nil {
-			log.Warn("Could not establish connection", "error", err, "receiver", receiver)
-			return err
+		switch receiver.(type) {
+		case *net.TCPAddr:
+			conn, err := createConnection(receiver, s.config.KeepAlivePeriod, s.certPool)
+			//add connection to cache
+			conns = append(conns, conn)
+			if err != nil {
+				log.Warn("Could not establish connection", "error", err, "receiver", receiver)
+				return err
+			}
+			s.caches.ConnCache.AddConnection(conn)
+			//handle connection
+			if tcpAddr, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
+				go s.handleConnection(conn, tcpAddr)
+			} else {
+				log.Warn("Type assertion failed. Expected *net.TCPAddr", "addr", conn.RemoteAddr())
+			}
+			//add capabilities to message
+			msg.Capabilities = []message.Capability{message.Capability(s.capabilityHash)}
+			conns = []net.Conn{conn}
+		case *connection.SCIONAddr:
+			return errors.New("unsupported protocol")
 		}
-		s.caches.ConnCache.AddConnection(conn)
-		//handle connection
-		if tcpAddr, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
-			go s.handleConnection(conn, tcpAddr)
-		} else {
-			log.Warn("Type assertion failed. Expected *net.TCPAddr", "addr", conn.RemoteAddr())
-		}
-		//add capabilities to message
-		msg.Capabilities = []message.Capability{message.Capability(s.capabilityHash)}
 	}
 	for _, conn := range conns {
 		log.Debug("Send message", "dst", conn.RemoteAddr(), "content", msg)
@@ -135,6 +159,42 @@ func (s *Server) listen() {
 			} else {
 				log.Warn("Type assertion failed. Expected *net.TCPAddr", "addr", conn.RemoteAddr())
 			}
+		}
+	case connection.SCION:
+		addr, ok := s.config.ServerAddress.Addr.(*connection.SCIONAddr)
+		if !ok {
+			log.Warn(fmt.Sprintf("Type assertion failed. Expected *connection.SCIONAddr, got %T", addr))
+			return
+		}
+		if err := snet.Init(addr.Local.IA, s.config.SciondSock, s.config.DispatcherSock); err != nil {
+			log.Warn("failed to snet.Init: %v", err)
+			return
+		}
+		listener, err := snet.ListenSCION("udp4", addr.Local)
+		if err != nil {
+			log.Warn("failed to ListenSCION: %v", err)
+			return
+		}
+		for {
+			buf := make([]byte, 9000)
+			n, addr, err := listener.ReadFromSCION(buf)
+			if err != nil {
+				log.Warn("Failed to ReadFromSCION: %v", err)
+				continue
+			}
+			data := buf[:n]
+			// Note: We cannot use handleConnection because UDP is connectionless and we have to
+			// manually stick the remote endpoint address in the handler.
+			var msg message.Message
+			if err := cbor.NewReader(bytes.NewReader(data)).Unmarshal(&msg); err != nil {
+				log.Warn("failed to unmarshal CBOR: %v", err)
+			}
+			remoteAddr := &connection.SCIONAddr{
+				Remote:     addr,
+				Underlying: listener,
+			}
+			deliver(&msg, remoteAddr,
+				s.queues.Prio, s.queues.Normal, s.queues.Notify, s.caches.PendingKeys)
 		}
 	default:
 		log.Warn("Unsupported Network address type.")


### PR DESCRIPTION
This commit adds the ability for `rainsd` to listen on a SCION socket using the `snet` library.

Two additional fields are added to the `rainsdConfig` struct:
```
	DispatcherSock string // Path to SCION dispatcher UNIX socket
	SciondSock     string // Path to appropriate SCIOND UNIX socket
```

This PR is dependent on https://github.com/scionproto/scion/pull/2253 to implement the configuration file parsing for `snet.Addr`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/rains/137)
<!-- Reviewable:end -->
