### PR TITLE
Checkpoint support for some rainsd caches

### DIFF
--- a/internal/pkg/cache/assertionCache.go
+++ b/internal/pkg/cache/assertionCache.go
@@ -243,6 +243,22 @@ func (c *AssertionImpl) RemoveZone(zone string) {
 	}
 }
 
+//Checkpoint returns all cached assertions
+func (c *AssertionImpl) Checkpoint() (assertions []*section.Assertion) {
+	entries := c.cache.GetAll()
+	for _, e := range entries {
+		values := e.(*assertionCacheValue)
+		values.mux.RLock()
+		if !values.deleted {
+			for _, v := range values.assertions {
+				assertions = append(assertions, v.assertion)
+			}
+		}
+		values.mux.RUnlock()
+	}
+	return
+}
+
 //Len returns the number of elements in the cache.
 func (c *AssertionImpl) Len() int {
 	return c.counter.Value()

--- a/internal/pkg/cache/interfaces.go
+++ b/internal/pkg/cache/interfaces.go
@@ -65,6 +65,8 @@ type ZonePublicKey interface {
 		keys.PublicKey, *section.Assertion, bool)
 	//RemoveExpiredKeys deletes all expired public keys from the cache.
 	RemoveExpiredKeys()
+	//Checkpoint returns all cached assertions
+	Checkpoint() []*section.Assertion
 	//Len returns the number of public keys currently in the cache.
 	Len() int
 }

--- a/internal/pkg/cache/interfaces.go
+++ b/internal/pkg/cache/interfaces.go
@@ -117,6 +117,8 @@ type Assertion interface {
 	//RemoveZone deletes all assertions in the assertionCache and consistencyCache of the given
 	//zone.
 	RemoveZone(zone string)
+	//Checkpoint returns all cached assertions
+	Checkpoint() []*section.Assertion
 	//Len returns the number of elements in the cache.
 	Len() int
 }
@@ -144,6 +146,8 @@ type NegativeAssertion interface {
 	//RemoveZone deletes all shards and zones in the assertionCache and consistencyCache of the
 	//given subjectZone.
 	RemoveZone(subjectZone string)
+	//Checkpoint returns all cached negative assertions
+	Checkpoint() []section.WithSigForward
 	//Len returns the number of elements in the cache.
 	Len() int
 }

--- a/internal/pkg/cache/zoneKeyCache.go
+++ b/internal/pkg/cache/zoneKeyCache.go
@@ -183,6 +183,18 @@ func (c *ZoneKeyImpl) RemoveExpiredKeys() {
 	}
 }
 
+//Checkpoint returns all cached assertions
+func (c *ZoneKeyImpl) Checkpoint() (assertions []*section.Assertion) {
+	entries := c.cache.GetAll()
+	for _, e := range entries {
+		values := e.(*zoneKeyCacheValue).publicKeys.GetAll()
+		for _, v := range values {
+			assertions = append(assertions, v.(publicKeyAssertion).assertion)
+		}
+	}
+	return
+}
+
 //Len returns the number of public keys currently in the cache.
 func (c *ZoneKeyImpl) Len() int {
 	return c.counter.Value()


### PR DESCRIPTION
This pull request extends the functionality of the assertion, negative assertion, and zone key cache to get a view of the full cache's current content.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/rains/147)
<!-- Reviewable:end -->
