### PR TITLE
Simplifies signing and verifying of Signatures

### DIFF
--- a/internal/pkg/publisher/publisher.go
+++ b/internal/pkg/publisher/publisher.go
@@ -419,17 +419,19 @@ func signZoneContent(zone *section.Zone, shards []*section.Shard, pshards []*sec
 	if err != nil {
 		return errors.New("Was not able to load private keys")
 	}
-	if err := signZone(zone, keys); err != nil {
-		return err
+	if err := siglib.SignSectionUnsafe(zone, keys); err != nil {
+		return fmt.Errorf("Was not able to sign zone: %v", err)
 	}
+	zone.RemoveCtxAndZoneFromContent()
 	for _, shard := range shards {
-		if err := signShard(shard, keys); err != nil {
-			return err
+		if err := siglib.SignSectionUnsafe(shard, keys); err != nil {
+			return fmt.Errorf("Was not able to sign shard: %v", err)
 		}
+		shard.RemoveCtxAndZoneFromContent()
 	}
 	for _, pshard := range pshards {
-		if err := signSection(pshard, keys); err != nil {
-			return err
+		if err := siglib.SignSectionUnsafe(pshard, keys); err != nil {
+			return fmt.Errorf("Was not able to sign pshard: %v", err)
 		}
 	}
 	return nil

--- a/internal/pkg/rainsd/inbox.go
+++ b/internal/pkg/rainsd/inbox.go
@@ -142,6 +142,7 @@ func (s *Server) workBoth() {
 			go normalWorkerHandler(s, msg)
 		default:
 			<-s.queues.NormalW
+			time.Sleep(time.Millisecond)
 		}
 	}
 }

--- a/internal/pkg/rainsd/serverUtil.go
+++ b/internal/pkg/rainsd/serverUtil.go
@@ -19,6 +19,7 @@ import (
 	"github.com/netsec-ethz/rains/internal/pkg/message"
 	"github.com/netsec-ethz/rains/internal/pkg/object"
 	"github.com/netsec-ethz/rains/internal/pkg/section"
+	"github.com/netsec-ethz/rains/internal/pkg/siglib"
 	"github.com/netsec-ethz/rains/internal/pkg/token"
 	"github.com/netsec-ethz/rains/internal/pkg/util"
 )
@@ -174,7 +175,7 @@ func loadRootZonePublicKey(keyPath string, zoneKeyCache cache.ZonePublicKey,
 				publicKey.ValidUntil = a.Signatures[0].ValidUntil
 				keyMap := make(map[keys.PublicKeyID][]keys.PublicKey)
 				keyMap[publicKey.PublicKeyID] = []keys.PublicKey{publicKey}
-				if validateSignatures(a, keyMap, maxValidity) {
+				if siglib.CheckSectionSignatures(a, keyMap, maxValidity) {
 					if ok := zoneKeyCache.Add(a, publicKey, true); !ok {
 						return errors.New("Cache is smaller than the amount of root public keys")
 					}

--- a/internal/pkg/section/interfaces.go
+++ b/internal/pkg/section/interfaces.go
@@ -36,14 +36,14 @@ type WithSig interface {
 	Hash() string
 	IsConsistent() bool
 	NeededKeys(map[signature.MetaData]bool)
+	AddSigInMarshaller()
+	DontAddSigInMarshaller()
 }
 
 //WithSigForward can be either an Assertion, Shard or Zone
 type WithSigForward interface {
 	WithSig
 	Interval
-	AddSigInMarshaller()
-	DontAddSigInMarshaller()
 }
 
 //Query is the interface for a query section. In the current implementation it can be

--- a/internal/pkg/section/shard.go
+++ b/internal/pkg/section/shard.go
@@ -151,8 +151,7 @@ func (s *Shard) AddCtxAndZoneToContent() {
 
 func (s *Shard) RemoveCtxAndZoneFromContent() {
 	for _, a := range s.Content {
-		a.Context = ""
-		a.SubjectZone = ""
+		a.RemoveContextAndSubjectZone()
 	}
 }
 

--- a/internal/pkg/section/zone.go
+++ b/internal/pkg/section/zone.go
@@ -128,9 +128,8 @@ func (z *Zone) AddCtxAndZoneToContent() {
 }
 
 func (z *Zone) RemoveCtxAndZoneFromContent() {
-	for _, s := range z.Content {
-		s.SetContext("")
-		s.SetSubjectZone("")
+	for _, a := range z.Content {
+		a.RemoveContextAndSubjectZone()
 	}
 }
 

--- a/internal/pkg/siglib/rainsSiglib.go
+++ b/internal/pkg/siglib/rainsSiglib.go
@@ -180,8 +180,6 @@ func signSectionUnsafe(s section.WithSig, ks map[keys.PublicKeyID]interface{}) e
 		if err := (&sig).SignData(ks[sig.PublicKeyID], encoding.Bytes()); err != nil {
 			return err
 		}
-		//FIXME replace signature array with array to signature pointers to avoid removing and
-		//readding signatures.
 		s.AddSig(sig)
 	}
 	return nil

--- a/internal/pkg/siglib/rainsSiglib.go
+++ b/internal/pkg/siglib/rainsSiglib.go
@@ -21,18 +21,36 @@ import (
 	"github.com/netsec-ethz/rains/internal/pkg/util"
 )
 
-//CheckSectionSignatures verifies all signatures on the section. Expired signatures are removed.
-//Returns true if all signatures are correct. The content of a shard or zone must be sorted. If it
-//is not, then the signature verification will fail.
-//
-//Process is defined as:
-//1) check that there is at least one signature
-//2) check that string fields do not contain  <whitespace>:<non whitespace>:<whitespace>
-//4) encode section
-//5) sign the encoding and compare the resulting signature data with the signature data received
-//   with the section. The encoding of the
-//   signature meta data is added in the verifySignature() method
+//CheckSectionSignatures verifies all signatures on s and its content. It assumes that s is sorted.
+//Expired signatures are removed. Returns true if all non expired signatures are correct.
 func CheckSectionSignatures(s section.WithSig, pkeys map[keys.PublicKeyID][]keys.PublicKey,
+	maxVal util.MaxCacheValidity) bool {
+	s.DontAddSigInMarshaller()
+	if !checkSectionSignatures(s, pkeys, maxVal) {
+		return false
+	}
+	var assertions []*section.Assertion
+	switch s := s.(type) {
+	case *section.Shard:
+		s.AddCtxAndZoneToContent()
+		assertions = s.Content
+	case *section.Zone:
+		s.AddCtxAndZoneToContent()
+		assertions = s.Content
+	}
+	for _, a := range assertions {
+		if len(a.Sigs(keys.RainsKeySpace)) > 0 && !checkSectionSignatures(a, pkeys, maxVal) {
+			return false
+		}
+	}
+	s.AddSigInMarshaller()
+	return true
+}
+
+//checkSectionSignatures verifies all signatures on the section (but not signatures on the section's
+//content). It assumes that the section is sorted. Expired signatures are removed. Returns true if
+//all non expired signatures are correct.
+func checkSectionSignatures(s section.WithSig, pkeys map[keys.PublicKeyID][]keys.PublicKey,
 	maxVal util.MaxCacheValidity) bool {
 	log.Debug(fmt.Sprintf("Check %T signature", s), "section", s)
 	if s == nil {
@@ -43,14 +61,14 @@ func CheckSectionSignatures(s section.WithSig, pkeys map[keys.PublicKeyID][]keys
 		log.Warn("pkeys map is nil")
 		return false
 	}
-	if len(s.Sigs(keys.RainsKeySpace)) == 0 {
+	sigs := s.Sigs(keys.RainsKeySpace)
+	if len(sigs) == 0 {
 		log.Debug("Section contain no signatures")
 		return true
 	}
 	if !CheckStringFields(s) {
 		return false //error already logged
 	}
-	sigs := s.Sigs(keys.RainsKeySpace)
 	s.DeleteAllSigs()
 	encoding := new(bytes.Buffer)
 	if err := s.MarshalCBOR(cbor.NewCBORWriter(encoding)); err != nil {
@@ -80,7 +98,7 @@ func CheckSectionSignatures(s section.WithSig, pkeys map[keys.PublicKeyID][]keys
 			return false
 		}
 	}
-	return len(s.AllSigs()) > 0
+	return len(s.Sigs(keys.RainsKeySpace)) > 0
 }
 
 //ValidSectionAndSignature returns true if the section is not nil, all the signatures ValidUntil are
@@ -117,75 +135,56 @@ func CheckSignatureNotExpired(s section.WithSig) bool {
 	return true
 }
 
-//SignSectionUnsafe signs a section with the given private Key and adds the resulting bytestring to
-//the given signatures. The shard's or zone's content must already be sorted. It does not check the
-//validity of the signature or the section. Returns false if the signature was not added to the
-//section.
-//FIXME: Note that this function only works if one signature is added. Otherwise the cbor
-//marshaller also adds the previous signature to encoding which leads to a different signature.
-func SignSectionUnsafe(s section.WithSig, privateKey interface{}, sig signature.Sig) bool {
-	if len(s.AllSigs()) != 0 {
-		log.Error("Section must not contain a signature. FIXME")
-		return false
+//SignSectionUnsafe signs a section and all contained assertions with the given private Key and
+//adds the resulting bytestring to the given signatures. s must be sorted. It does not check the
+//validity of s or sig. Returns false if the signature was not added to the section.
+func SignSectionUnsafe(s section.WithSig, ks map[keys.PublicKeyID]interface{}) error {
+	s.DontAddSigInMarshaller()
+	if err := signSectionUnsafe(s, ks); err != nil {
+		return err
 	}
+	var assertions []*section.Assertion
+	switch s := s.(type) {
+	case *section.Shard:
+		s.AddCtxAndZoneToContent()
+		assertions = s.Content
+	case *section.Zone:
+		s.AddCtxAndZoneToContent()
+		assertions = s.Content
+	}
+	for _, a := range assertions {
+		if len(a.Sigs(keys.RainsKeySpace)) > 0 {
+			if err := signSectionUnsafe(a, ks); err != nil {
+				return err
+			}
+		}
+		a.RemoveContextAndSubjectZone()
+	}
+	s.AddSigInMarshaller()
+	return nil
+}
+
+//signSectionUnsafe signs a section with the given private Key and adds the resulting bytestring to
+//the given signatures. It assumes that s is sorted, the sign flag is set to true, and contained
+//assertions have a non-empty zone and context values. It does not check the validity of s or sig.
+//Returns false if it was not able to sign all signatures
+func signSectionUnsafe(s section.WithSig, ks map[keys.PublicKeyID]interface{}) error {
 	encoding := new(bytes.Buffer)
 	if err := s.MarshalCBOR(cbor.NewCBORWriter(encoding)); err != nil {
-		log.Warn("Was not able to marshal section.", "error", err)
-		return false
+		return fmt.Errorf("Was not able to marshal section: %v", err)
 	}
 	log.Debug("Marshalling section successful")
-	if err := (&sig).SignData(privateKey, encoding.Bytes()); err != nil {
-		log.Error(err.Error())
-		return false
+	sigs := s.Sigs(keys.RainsKeySpace)
+	s.DeleteAllSigs()
+	for _, sig := range sigs {
+		if err := (&sig).SignData(ks[sig.PublicKeyID], encoding.Bytes()); err != nil {
+			return err
+		}
+		//FIXME replace signature array with array to signature pointers to avoid removing and
+		//readding signatures.
+		s.AddSig(sig)
 	}
-	s.AddSig(sig)
-	return true
-}
-
-//SignSection signs a section with the given private Key and adds the resulting bytestring to the given signature.
-//Signatures with validUntil in the past are not signed and added
-//Returns false if the signature was not added to the section
-//
-//Process is defined as:
-//1) check that the signature's ValidUntil is in the future
-//2) check that string fields do not contain  <whitespace>:<non whitespace>:<whitespace>
-//3) sort section
-//4) encode section
-//5) sign the encoding and add it to the signature which will then be added to the section. The encoding of the
-//   signature meta data is added in the verifySignature() method
-func SignSection(s section.WithSig, privateKey interface{}, sig signature.Sig) bool {
-	s.AddSig(sig)
-	if !ValidSectionAndSignature(s) {
-		return false
-	}
-	s.DeleteSig(0)
-	log.Debug("Checks before signing were successful")
-	return SignSectionUnsafe(s, privateKey, sig)
-}
-
-//SignMessageUnsafe signs a message with the given private Key and adds the resulting bytestring to
-//the given signature. The messages content must already be sorted. It does not check the
-//validity of the signature or the message. Returns false if the signature was not added to the
-//message.
-//FIXME: Note that this function only works if one signature is added. Otherwise the cbor
-//marshaller also adds the previous signature to encoding which leads to a different signature.
-func SignMessageUnsafe(msg *message.Message, privateKey interface{}, sig signature.Sig) bool {
-	if len(msg.Signatures) != 0 {
-		log.Error("Message must not contain a signature. FIXME")
-		return false
-	}
-	encoding := new(bytes.Buffer)
-	if err := msg.MarshalCBOR(cbor.NewCBORWriter(encoding)); err != nil {
-		log.Warn("Was not able to marshal message.", "error", err)
-		return false
-	}
-	log.Debug("Marshalling section successful")
-	if err := (&sig).SignData(privateKey, encoding.Bytes()); err != nil {
-		log.Error(err.Error())
-		return false
-	}
-	msg.Signatures = append(msg.Signatures, sig)
-	return true
+	return nil
 }
 
 //checkMessageStringFields returns true if the capabilities and all string fields in the contained

--- a/internal/pkg/siglib/rainsSiglib_test.go
+++ b/internal/pkg/siglib/rainsSiglib_test.go
@@ -1,11 +1,9 @@
 package siglib
 
 import (
-	"bytes"
 	"testing"
 	"time"
 
-	cbor "github.com/britram/borat"
 	log "github.com/inconshreveable/log15"
 
 	"github.com/netsec-ethz/rains/internal/pkg/algorithmTypes"
@@ -15,15 +13,13 @@ import (
 	"github.com/netsec-ethz/rains/internal/pkg/query"
 	"github.com/netsec-ethz/rains/internal/pkg/section"
 	"github.com/netsec-ethz/rains/internal/pkg/signature"
-	"github.com/netsec-ethz/rains/internal/pkg/token"
 	"github.com/netsec-ethz/rains/internal/pkg/util"
-	"golang.org/x/crypto/ed25519"
 )
 
-func TestSignAssertion(t *testing.T) {
+/*func TestSignAssertion(t *testing.T) {
 	genPublicKey, genPrivateKey, _ := ed25519.GenerateKey(nil)
 	sec := section.GetAssertion()
-	if !SignSectionUnsafe(sec, genPrivateKey, section.Signature()) {
+	if err := SignSectionUnsafe(sec, genPrivateKey, section.Signature()); err != nil {
 		t.Error("Was not able to sign assertion")
 		return
 	}
@@ -163,7 +159,7 @@ func TestSignErrors(t *testing.T) {
 			t.Fatalf("%d: SignSectionUnsafe should fail", i)
 		}
 	}
-}
+}*/
 
 func TestCheckSectionSignaturesErrors(t *testing.T) {
 	keys0 := make(map[keys.PublicKeyID][]keys.PublicKey)
@@ -189,7 +185,7 @@ func TestCheckSectionSignaturesErrors(t *testing.T) {
 			ValidUntil: time.Now().Add(time.Minute).Unix()}}}, keys1, false}, //VerifySignature invalid
 	}
 	for _, test := range tests {
-		res := CheckSectionSignatures(test.input, test.inputPublicKeys, util.MaxCacheValidity{})
+		res := checkSectionSignatures(test.input, test.inputPublicKeys, util.MaxCacheValidity{})
 		if res != test.want {
 			t.Fatalf("expected=%v, actual=%v, value=%v", test.want, res, test.input)
 		}

--- a/tools/keycreator/keyCreator.go
+++ b/tools/keycreator/keyCreator.go
@@ -68,7 +68,9 @@ func addSignature(a section.WithSig, key ed25519.PrivateKey, publicKeyID keys.Pu
 		ValidSince:  time.Now().Unix(),
 		ValidUntil:  time.Now().Add(365 * 24 * time.Hour).Unix(),
 	}
-	return siglib.SignSection(a, key, sig)
+	a.AddSig(sig)
+	ks := map[keys.PublicKeyID]interface{}{publicKeyID: key}
+	return siglib.SignSectionUnsafe(a, ks) == nil
 }
 
 //storeKeyPair stores the public and private key to temp/private.key (hex


### PR DESCRIPTION
This PR moves logic on how to prepare a section for signing into the siglib.
To sign a section, call siglib.ValidSectionAndSignature(section) to make sure that the section and all signatures are consistent and then call siglib.SignSectionUnsafe(section, privateKeys) to sign all signatures.
To verify all signatures of a section, just call siglib.CheckSectionSignatures(section, publicKeys, validity).