### PR TITLE
Symmetric signature checking

### DIFF
--- a/internal/pkg/rainsd/assertionEngine.go
+++ b/internal/pkg/rainsd/assertionEngine.go
@@ -117,7 +117,6 @@ func addShardToCache(shard *section.Shard, isAuthoritative bool, assertionsCache
 			a := assertion.Copy(shard.Context, shard.SubjectZone)
 			addAssertionToCache(a, isAuthoritative, assertionsCache, zoneKeyCache)
 		}
-		assertion.RemoveContextAndSubjectZone()
 	}
 	negAssertionCache.AddShard(shard, shard.ValidUntil(), isAuthoritative)
 	log.Debug("Added shard to cache", "shard", *shard)
@@ -139,7 +138,6 @@ func addZoneToCache(zone *section.Zone, isAuthoritative bool, assertionsCache ca
 			a := assertion.Copy(zone.Context, zone.SubjectZone)
 			addAssertionToCache(a, isAuthoritative, assertionsCache, zoneKeyCache)
 		}
-		assertion.RemoveContextAndSubjectZone()
 	}
 	negAssertionCache.AddZone(zone, zone.ValidUntil(), isAuthoritative)
 	log.Debug("Added zone to cache", "zone", *zone)

--- a/internal/pkg/siglib/rainsSiglib_test.go
+++ b/internal/pkg/siglib/rainsSiglib_test.go
@@ -76,9 +76,9 @@ func TestCheckSectionSignaturesErrors(t *testing.T) {
 		inputPublicKeys map[keys.PublicKeyID][]keys.PublicKey
 		want            bool
 	}{
-		{nil, nil, false},                   //msg nil
-		{&section.Assertion{}, nil, false},  //pkeys nil
-		{&section.Assertion{}, keys0, true}, //no signatures
+		{nil, nil, false},                                                                                                                                //msg nil
+		{&section.Assertion{}, nil, false},                                                                                                               //pkeys nil
+		{&section.Assertion{}, keys0, true},                                                                                                              //no signatures
 		{&section.Assertion{Signatures: []signature.Sig{signature.Sig{}}, SubjectName: ":ip55:"}, keys0, false},                                          //checkStringField false
 		{&section.Assertion{Signatures: []signature.Sig{signature.Sig{}}}, keys0, false},                                                                 //no matching algotype in keys
 		{&section.Assertion{Signatures: []signature.Sig{signature.Sig{PublicKeyID: keys.PublicKeyID{Algorithm: algorithmTypes.Ed25519}}}}, keys1, false}, //sig expired


### PR DESCRIPTION
The signature library does not change the content of contained assertions.
It still removes expired signatures

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/rains/195)
<!-- Reviewable:end -->
