### PR TITLE
Zonefile serialization bug

### DIFF
--- a/internal/pkg/zonefile/test/newzonefile.txt
+++ b/internal/pkg/zonefile/test/newzonefile.txt
@@ -1,45 +1,45 @@
 :Z: ch. . [
-    :A: ch [ :name:    a [ :ip4: :ip6: ] ]
-    :A: ch [ :ip4:     192.168.1.10 ]
+    :A: ch [ :name:      a [ :ip4: :ip6: ] ]
+    :A: ch [ :ip4:       192.168.1.10 ]
     :A: ethz [ 
-        :ip6:     2001:0db8:85a3:0000:0000:8a2e:0370:7334
-        :ip4:     129.132.128.139
+        :ip6:       2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        :ip4:       129.132.128.139
     ]
-    :A: ch [ :redir:   ns.ch. ]
-    :A: ch [ :deleg:   :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
-    :A: ch [ :nameset: [:alpha:][:alnum:]* ]
-    :A: ch [ :cert:    :tls: :endEntity: :sha256: e28b1bd3a73882b198dfe4f0fa954c ]
-    :A: ch [ :srv:     dns 53 0 ]
-    :A: ch [ :regr:    registrar text ]
-    :A: ch [ :regt:    registrant info ]
-    :A: ch [ :infra:   :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
-    :A: ch [ :extra:    :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
-    :A: ch [ :next:    :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 100000 20000000 ]
-    :A: ch [ :ip4:     192.168.1.10 ]
-    :A: ch [ :ip4:     192.168.1.10 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
+    :A: ch [ :redir:     ns.ch. ]
+    :A: ch [ :deleg:     :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
+    :A: ch [ :nameset:   [:alpha:][:alnum:]* ]
+    :A: ch [ :cert:      :tls: :endEntity: :sha256: e28b1bd3a73882b198dfe4f0fa954c ]
+    :A: ch [ :srv:       dns 53 0 ]
+    :A: ch [ :regr:      registrar text ]
+    :A: ch [ :regt:      registrant info ]
+    :A: ch [ :infra:     :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
+    :A: ch [ :extra:      :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
+    :A: ch [ :next:      :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 100000 20000000 ]
+    :A: ch [ :ip4:       192.168.1.10 ]
+    :A: ch [ :ip4:       192.168.1.10 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
 
 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
 
 :S: ch. . < > [
-    :A: ch [ :name:    a [ :ip4: :ip6: ] ]
-    :A: ch [ :ip4:     192.168.1.10 ]
+    :A: ch [ :name:      a [ :ip4: :ip6: ] ]
+    :A: ch [ :ip4:       192.168.1.10 ]
     :A: ethz [ 
-        :ip6:     2001:0db8:85a3:0000:0000:8a2e:0370:7334
-        :ip6:     129.132.128.139
+        :ip6:       2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        :ip6:       129.132.128.139
     ]
-    :A: ch [ :redir:   ns.ch. ]
-    :A: ch [ :deleg:   :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
-    :A: ch [ :nameset: [:alpha:][:alnum:]* ]
-    :A: ch [ :cert:    :tls: :endEntity: :sha256: e28b1bd3a73882b198dfe4f0fa954c ]
-    :A: ch [ :srv:     dns 53 0 ]
-    :A: ch [ :regr:    registrar text ]
-    :A: ch [ :regt:    registrant info ]
-    :A: ch [ :infra:   :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
-    :A: ch [ :extra:    :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
-    :A: ch [ :next:    :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 100000 20000000 ]
-    :A: ch [ :ip4:     192.168.1.10 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
+    :A: ch [ :redir:     ns.ch. ]
+    :A: ch [ :deleg:     :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
+    :A: ch [ :nameset:   [:alpha:][:alnum:]* ]
+    :A: ch [ :cert:      :tls: :endEntity: :sha256: e28b1bd3a73882b198dfe4f0fa954c ]
+    :A: ch [ :srv:       dns 53 0 ]
+    :A: ch [ :regr:      registrar text ]
+    :A: ch [ :regt:      registrant info ]
+    :A: ch [ :infra:     :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
+    :A: ch [ :extra:      :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
+    :A: ch [ :next:      :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 100000 20000000 ]
+    :A: ch [ :ip4:       192.168.1.10 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
 
-    :A: ch [ :ip4:     192.168.1.10 ]
+    :A: ch [ :ip4:       192.168.1.10 ]
 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
 
 :P: ch. . < > :bloomKM12: :shake256: e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
@@ -50,4 +50,6 @@
 
 :P: ch. . < > :bloomKM24: :shake256: e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ( :sig: :ed25519: :rains: 1 2000 5000 )
 
-:A: www ch. . [ :ip4:     192.168.1.10 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
+:A: www ch. . [ :ip4:       192.168.1.10 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
+
+:A: www ethz.ch. . [ :scionip6:  2-ff00:0:222,[2001:db8:85a3::8a2e:370:7334] ]

--- a/internal/pkg/zonefile/test/newzonefile.txt
+++ b/internal/pkg/zonefile/test/newzonefile.txt
@@ -1,7 +1,7 @@
 :Z: ch. . [
     :A: ch [ :name:      a [ :ip4: :ip6: ] ]
     :A: ch [ :ip4:       192.168.1.10 ]
-    :A: ethz [ 
+    :A: ethz [
         :ip6:       2001:0db8:85a3:0000:0000:8a2e:0370:7334
         :ip4:       129.132.128.139
     ]
@@ -13,7 +13,7 @@
     :A: ch [ :regr:      registrar text ]
     :A: ch [ :regt:      registrant info ]
     :A: ch [ :infra:     :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
-    :A: ch [ :extra:      :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
+    :A: ch [ :extra:     :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
     :A: ch [ :next:      :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 100000 20000000 ]
     :A: ch [ :ip4:       192.168.1.10 ]
     :A: ch [ :ip4:       192.168.1.10 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
@@ -23,7 +23,7 @@
 :S: ch. . < > [
     :A: ch [ :name:      a [ :ip4: :ip6: ] ]
     :A: ch [ :ip4:       192.168.1.10 ]
-    :A: ethz [ 
+    :A: ethz [
         :ip6:       2001:0db8:85a3:0000:0000:8a2e:0370:7334
         :ip6:       129.132.128.139
     ]
@@ -35,7 +35,7 @@
     :A: ch [ :regr:      registrar text ]
     :A: ch [ :regt:      registrant info ]
     :A: ch [ :infra:     :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
-    :A: ch [ :extra:      :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
+    :A: ch [ :extra:     :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
     :A: ch [ :next:      :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 100000 20000000 ]
     :A: ch [ :ip4:       192.168.1.10 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
 

--- a/internal/pkg/zonefile/test/zonefile.txt
+++ b/internal/pkg/zonefile/test/zonefile.txt
@@ -13,7 +13,7 @@
     :A: ch [ :regr:      registrar text ]
     :A: ch [ :regt:      registrant info ]
     :A: ch [ :infra:     :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
-    :A: ch [ :extra:      :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
+    :A: ch [ :extra:     :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
     :A: ch [ :next:      :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 100000 20000000 ]
     :A: ch [ :ip4:       192.168.1.10 ]
     :A: ch [ :ip4:       192.168.1.10 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
@@ -35,7 +35,7 @@
     :A: ch [ :regr:      registrar text ]
     :A: ch [ :regt:      registrant info ]
     :A: ch [ :infra:     :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
-    :A: ch [ :extra:      :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
+    :A: ch [ :extra:     :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
     :A: ch [ :next:      :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 100000 20000000 ]
     :A: ch [ :ip4:       192.168.1.10 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
 

--- a/internal/pkg/zonefile/test/zonefile.txt
+++ b/internal/pkg/zonefile/test/zonefile.txt
@@ -1,65 +1,55 @@
 :Z: ch. . [
-         :A: ch  [ :name: a [ :ip4: :ip6: ] ]
-         :A: ch  [ :ip4: 192.168.1.10 ]
-         :A: ethz [ 
-                 :ip6:      2001:0db8:85a3:0000:0000:8a2e:0370:7334
-                 :ip4:      129.132.128.139
-         ]
-         :A: ch [ :redir: ns.ch. ]
-         :A: ch  [ :deleg: :ed25519: 5
-         e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
-         ]
-         :A: ch  [ :nameset: [:alpha:][:alnum:]* ]
-         :A: ch  [ :cert: :tls: :endEntity: :sha256: e28b1bd3a73882b198dfe4f0fa954c ]
-         :A: ch  [ :srv: dns 53 0 ]
-         :A: ch  [ :regr: registrar text ]
-         :A: ch  [ :regt: registrant info ]
-         :A: ch  [ :infra: :ed25519: 5
-         e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
-         ]
-         :A: ch  [ :extra: :ed25519: 5
-         e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
-         ]
-         :A: ch  [ :next: :ed25519: 5
-         e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
-         100000 20000000 ]
-         :A: ch  [ :ip4: 192.168.1.10 ]
-         :A: ch  [ :ip4: 192.168.1.10 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
+    :A: ch [ :name:      a [ :ip4: :ip6: ] ]
+    :A: ch [ :ip4:       192.168.1.10 ]
+    :A: ethz [
+        :ip6:       2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        :ip4:       129.132.128.139
+    ]
+    :A: ch [ :redir:     ns.ch. ]
+    :A: ch [ :deleg:     :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
+    :A: ch [ :nameset:   [:alpha:][:alnum:]* ]
+    :A: ch [ :cert:      :tls: :endEntity: :sha256: e28b1bd3a73882b198dfe4f0fa954c ]
+    :A: ch [ :srv:       dns 53 0 ]
+    :A: ch [ :regr:      registrar text ]
+    :A: ch [ :regt:      registrant info ]
+    :A: ch [ :infra:     :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
+    :A: ch [ :extra:      :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
+    :A: ch [ :next:      :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 100000 20000000 ]
+    :A: ch [ :ip4:       192.168.1.10 ]
+    :A: ch [ :ip4:       192.168.1.10 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
+
 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
 
 :S: ch. . < > [
-         :A: ch  [ :name: a [ :ip4: :ip6: ] ]
-         :A: ch  [ :ip4: 192.168.1.10 ]
-         :A: ethz [ 
-                 :ip6:      2001:0db8:85a3:0000:0000:8a2e:0370:7334
-                 :ip6:      129.132.128.139
-         ]
-         :A: ch [ :redir: ns.ch. ]
-         :A: ch  [ :deleg: :ed25519: 5
-         e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
-         ]
-         :A: ch  [ :nameset: [:alpha:][:alnum:]* ]
-         :A: ch  [ :cert: :tls: :endEntity: :sha256: e28b1bd3a73882b198dfe4f0fa954c ]
-         :A: ch  [ :srv: dns 53 0 ]
-         :A: ch  [ :regr: registrar text ]
-         :A: ch  [ :regt: registrant info ]
-         :A: ch  [ :infra: :ed25519: 5
-         e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
-         ]
-         :A: ch  [ :extra: :ed25519: 5
-         e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
-         ]
-         :A: ch  [ :next: :ed25519: 5
-         e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
-         100000 20000000 ]
-         :A: ch  [ :ip4: 192.168.1.10 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
-         :A: ch  [ :ip4: 192.168.1.10 ]
+    :A: ch [ :name:      a [ :ip4: :ip6: ] ]
+    :A: ch [ :ip4:       192.168.1.10 ]
+    :A: ethz [
+        :ip6:       2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        :ip6:       129.132.128.139
+    ]
+    :A: ch [ :redir:     ns.ch. ]
+    :A: ch [ :deleg:     :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
+    :A: ch [ :nameset:   [:alpha:][:alnum:]* ]
+    :A: ch [ :cert:      :tls: :endEntity: :sha256: e28b1bd3a73882b198dfe4f0fa954c ]
+    :A: ch [ :srv:       dns 53 0 ]
+    :A: ch [ :regr:      registrar text ]
+    :A: ch [ :regt:      registrant info ]
+    :A: ch [ :infra:     :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
+    :A: ch [ :extra:      :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ]
+    :A: ch [ :next:      :ed25519: 5 e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 100000 20000000 ]
+    :A: ch [ :ip4:       192.168.1.10 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
+
+    :A: ch [ :ip4:       192.168.1.10 ]
 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
 
 :P: ch. . < > :bloomKM12: :shake256: e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
-:P: ch. . < > :bloomKM16: :fnv128: e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
-:P: ch. . < > :bloomKM20: :fnv64: e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
-:P: ch. . < > :bloomKM24: :shake256: e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
-( :sig: :ed25519: :rains: 1 2000 5000 )
 
-:A: www ch. . [ :ip4: 192.168.1.10 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
+:P: ch. . < > :bloomKM16: :fnv128: e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
+
+:P: ch. . < > :bloomKM20: :fnv64: e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702
+
+:P: ch. . < > :bloomKM24: :shake256: e28b1bd3a73882b198dfe4f0fa95403c5916ac7b97387bd20f49511de628b702 ( :sig: :ed25519: :rains: 1 2000 5000 )
+
+:A: www ch. . [ :ip4:       192.168.1.10 ] ( :sig: :ed25519: :rains: 1 2000 5000 )
+
+:A: www ethz.ch. . [ :scionip6:  2-ff00:0:222,[2001:db8:85a3::8a2e:370:7334] ]

--- a/internal/pkg/zonefile/zoneFileEncoder.go
+++ b/internal/pkg/zonefile/zoneFileEncoder.go
@@ -124,9 +124,9 @@ func encodeBloomFilter(b section.BloomFilter) string {
 func encodeAssertion(a *section.Assertion, context, zone, indent string, addZoneAndContext bool) string {
 	var assertion string
 	if addZoneAndContext {
-		assertion = fmt.Sprintf("%s%s %s %s %s [ ", indent, TypeAssertion, a.SubjectName, zone, context)
+		assertion = fmt.Sprintf("%s%s %s %s %s [", indent, TypeAssertion, a.SubjectName, zone, context)
 	} else {
-		assertion = fmt.Sprintf("%s%s %s [ ", indent, TypeAssertion, a.SubjectName)
+		assertion = fmt.Sprintf("%s%s %s [", indent, TypeAssertion, a.SubjectName)
 	}
 	signature := ""
 	if a.Signatures != nil {
@@ -143,7 +143,7 @@ func encodeAssertion(a *section.Assertion, context, zone, indent string, addZone
 	if len(a.Content) > 1 {
 		return fmt.Sprintf("%s\n%s\n%s]%s", assertion, encodeObjects(a.Content, indent+indent4), indent, signature)
 	}
-	return fmt.Sprintf("%s%s ]%s", assertion, encodeObjects(a.Content, ""), signature)
+	return fmt.Sprintf("%s %s ]%s", assertion, encodeObjects(a.Content, ""), signature)
 }
 
 //encodeObjects returns o in zonefile format.
@@ -200,21 +200,21 @@ func encodeObjects(o []object.Object, indent string) string {
 			if pkey, ok := obj.Value.(keys.PublicKey); ok {
 				encoding += fmt.Sprintf("%s%s", addIndentToType(TypeInfraKey), encodeEd25519PublicKey(pkey))
 			} else {
-				log.Warn("Type assertion failed. Expected object.PublicKey", "actualType", fmt.Sprintf("%T", obj.Value))
+				log.Warn("Type assertion failed. Expected object.OTInfraKey", "actualType", fmt.Sprintf("%T", obj.Value))
 				return ""
 			}
 		case object.OTExtraKey:
 			if pkey, ok := obj.Value.(keys.PublicKey); ok {
-				encoding += fmt.Sprintf("%s %s", addIndentToType(TypeExternalKey), encodeEd25519PublicKey(pkey))
+				encoding += fmt.Sprintf("%s%s", addIndentToType(TypeExternalKey), encodeEd25519PublicKey(pkey))
 			} else {
-				log.Warn("Type assertion failed. Expected object.PublicKey", "actualType", fmt.Sprintf("%T", obj.Value))
+				log.Warn("Type assertion failed. Expected object.OTExtraKey", "actualType", fmt.Sprintf("%T", obj.Value))
 				return ""
 			}
 		case object.OTNextKey:
 			if pkey, ok := obj.Value.(keys.PublicKey); ok {
 				encoding += fmt.Sprintf("%s%s %d %d", addIndentToType(TypeNextKey), encodeEd25519PublicKey(pkey), pkey.ValidSince, pkey.ValidUntil)
 			} else {
-				log.Warn("Type assertion failed. Expected object.PublicKey", "actualType", fmt.Sprintf("%T", obj.Value))
+				log.Warn("Type assertion failed. Expected object.OTNextKey ", "actualType", fmt.Sprintf("%T", obj.Value))
 				return ""
 			}
 		default:

--- a/internal/pkg/zonefile/zoneFileEncoder.go
+++ b/internal/pkg/zonefile/zoneFileEncoder.go
@@ -229,7 +229,7 @@ func encodeObjects(o []object.Object, indent string) string {
 //addIndentToType returns the object type ot with appropriate indent such that the object value start at the same
 //indent.
 func addIndentToType(ot string) string {
-	result := "          "
+	result := indent12
 	return ot + result[len(ot):]
 }
 

--- a/internal/pkg/zonefile/zoneFileIOTestData.go
+++ b/internal/pkg/zonefile/zoneFileIOTestData.go
@@ -77,37 +77,37 @@ func getObjectsAndEncodings() (objectIndent, []string) {
 	}
 
 	nameObject0 := object.Object{Type: object.OTName, Value: nameObjectContent}
-	nameObjectEncoding0 := ":name:    ethz2.ch [ :ip4: :ip6: ]\n"
+	nameObjectEncoding0 := ":name:      ethz2.ch [ :ip4: :ip6: ]\n"
 	ip6Object0 := object.Object{Type: object.OTIP6Addr, Value: "2001:0db8:85a3:0000:0000:8a2e:0370:7334"}
-	ip6ObjectEncoding0 := ":ip6:     2001:0db8:85a3:0000:0000:8a2e:0370:7334\n"
+	ip6ObjectEncoding0 := ":ip6:       2001:0db8:85a3:0000:0000:8a2e:0370:7334\n"
 	ip4Object0 := object.Object{Type: object.OTIP4Addr, Value: "127.0.0.1"}
-	ip4ObjectEncoding0 := ":ip4:     127.0.0.1\n"
+	ip4ObjectEncoding0 := ":ip4:       127.0.0.1\n"
 	redirObject0 := object.Object{Type: object.OTRedirection, Value: "ns.ethz.ch"}
-	redirObjectEncoding0 := ":redir:   ns.ethz.ch\n"
+	redirObjectEncoding0 := ":redir:     ns.ethz.ch\n"
 	delegObject0 := object.Object{Type: object.OTDelegation, Value: publicKey}
-	delegObjectEncoding0 := fmt.Sprintf(":deleg:   :ed25519: 0 %s\n", hex.EncodeToString(publicKey.Key.(ed25519.PublicKey)))
+	delegObjectEncoding0 := fmt.Sprintf(":deleg:     :ed25519: 0 %s\n", hex.EncodeToString(publicKey.Key.(ed25519.PublicKey)))
 	nameSetObject0 := object.Object{Type: object.OTNameset, Value: object.NamesetExpr("Would be an expression")}
-	nameSetObjectEncoding0 := ":nameset: Would be an expression\n"
+	nameSetObjectEncoding0 := ":nameset:   Would be an expression\n"
 	certObject0 := object.Object{Type: object.OTCertInfo, Value: certificate0}
-	certObjectEncoding0 := fmt.Sprintf(":cert:    :tls: :endEntity: :sha256: %s\n", hex.EncodeToString(certificate0.Data))
+	certObjectEncoding0 := fmt.Sprintf(":cert:      :tls: :endEntity: :sha256: %s\n", hex.EncodeToString(certificate0.Data))
 	certObject1 := object.Object{Type: object.OTCertInfo, Value: certificate1}
-	certObjectEncoding1 := fmt.Sprintf(":cert:    :unspecified: :trustAnchor: :sha512: %s\n", hex.EncodeToString(certificate1.Data))
+	certObjectEncoding1 := fmt.Sprintf(":cert:      :unspecified: :trustAnchor: :sha512: %s\n", hex.EncodeToString(certificate1.Data))
 	certObject2 := object.Object{Type: object.OTCertInfo, Value: certificate2}
-	certObjectEncoding2 := fmt.Sprintf(":cert:    :unspecified: :trustAnchor: :sha384: %s\n", hex.EncodeToString(certificate2.Data))
+	certObjectEncoding2 := fmt.Sprintf(":cert:      :unspecified: :trustAnchor: :sha384: %s\n", hex.EncodeToString(certificate2.Data))
 	certObject3 := object.Object{Type: object.OTCertInfo, Value: certificate3}
-	certObjectEncoding3 := fmt.Sprintf(":cert:    :unspecified: :trustAnchor: :noHash: %s\n", hex.EncodeToString(certificate3.Data))
+	certObjectEncoding3 := fmt.Sprintf(":cert:      :unspecified: :trustAnchor: :noHash: %s\n", hex.EncodeToString(certificate3.Data))
 	serviceInfoObject0 := object.Object{Type: object.OTServiceInfo, Value: serviceInfo}
-	serviceInfoObjectEncoding0 := ":srv:     lookup 49830 1\n"
+	serviceInfoObjectEncoding0 := ":srv:       lookup 49830 1\n"
 	registrarObject0 := object.Object{Type: object.OTRegistrar, Value: "Registrar information"}
-	registrarObjectEncoding0 := ":regr:    Registrar information\n"
+	registrarObjectEncoding0 := ":regr:      Registrar information\n"
 	registrantObject0 := object.Object{Type: object.OTRegistrant, Value: "Registrant information"}
-	registrantObjectEncoding0 := ":regt:    Registrant information\n"
+	registrantObjectEncoding0 := ":regt:      Registrant information\n"
 	infraObject0 := object.Object{Type: object.OTInfraKey, Value: publicKey}
-	infraObjectEncoding0 := fmt.Sprintf(":infra:   :ed25519: 0 %s\n", hex.EncodeToString(publicKey.Key.(ed25519.PublicKey)))
+	infraObjectEncoding0 := fmt.Sprintf(":infra:     :ed25519: 0 %s\n", hex.EncodeToString(publicKey.Key.(ed25519.PublicKey)))
 	extraObject0 := object.Object{Type: object.OTExtraKey, Value: publicKey}
-	extraObjectEncoding0 := fmt.Sprintf(":extra:    :ed25519: 0 %s\n", hex.EncodeToString(publicKey.Key.(ed25519.PublicKey)))
+	extraObjectEncoding0 := fmt.Sprintf(":extra:      :ed25519: 0 %s\n", hex.EncodeToString(publicKey.Key.(ed25519.PublicKey)))
 	nextObject0 := object.Object{Type: object.OTNextKey, Value: publicKeyWithValidity}
-	nextObjectEncoding0 := fmt.Sprintf(":next:    :ed25519: 0 %s 1000 20000\n", hex.EncodeToString(publicKey.Key.(ed25519.PublicKey)))
+	nextObjectEncoding0 := fmt.Sprintf(":next:      :ed25519: 0 %s 1000 20000\n", hex.EncodeToString(publicKey.Key.(ed25519.PublicKey)))
 
 	objects = append(objects, []object.Object{nameObject0, ip6Object0, ip4Object0, redirObject0, delegObject0, nameSetObject0, certObject0, serviceInfoObject0,
 		registrarObject0, registrantObject0, infraObject0, extraObject0, nextObject0})

--- a/internal/pkg/zonefile/zoneFileIOTestData.go
+++ b/internal/pkg/zonefile/zoneFileIOTestData.go
@@ -105,7 +105,7 @@ func getObjectsAndEncodings() (objectIndent, []string) {
 	infraObject0 := object.Object{Type: object.OTInfraKey, Value: publicKey}
 	infraObjectEncoding0 := fmt.Sprintf(":infra:     :ed25519: 0 %s\n", hex.EncodeToString(publicKey.Key.(ed25519.PublicKey)))
 	extraObject0 := object.Object{Type: object.OTExtraKey, Value: publicKey}
-	extraObjectEncoding0 := fmt.Sprintf(":extra:      :ed25519: 0 %s\n", hex.EncodeToString(publicKey.Key.(ed25519.PublicKey)))
+	extraObjectEncoding0 := fmt.Sprintf(":extra:     :ed25519: 0 %s\n", hex.EncodeToString(publicKey.Key.(ed25519.PublicKey)))
 	nextObject0 := object.Object{Type: object.OTNextKey, Value: publicKeyWithValidity}
 	nextObjectEncoding0 := fmt.Sprintf(":next:      :ed25519: 0 %s 1000 20000\n", hex.EncodeToString(publicKey.Key.(ed25519.PublicKey)))
 

--- a/internal/pkg/zonefile/zoneFileIO_test.go
+++ b/internal/pkg/zonefile/zoneFileIO_test.go
@@ -34,7 +34,7 @@ func TestEncodeDecodeZone(t *testing.T) {
 	}
 	for go1 {
 		if scanner1.Text() != scanner2.Text() {
-			t.Error("Content is different", scanner1.Text(), scanner2.Text())
+			t.Error("Content is different at token level", scanner1.Text(), scanner2.Text())
 		}
 		go1 = scanner1.Scan()
 		go2 = scanner2.Scan()
@@ -45,12 +45,25 @@ func TestEncodeDecodeZone(t *testing.T) {
 
 	// Check reencoding single assertions works
 	scanner3 := bufio.NewScanner(bytes.NewReader(origData))
+	scanner4 := bufio.NewScanner(bytes.NewReader(newData))
 	scanner3.Split(bufio.ScanLines)
+	scanner4.Split(bufio.ScanLines)
 	go3 := scanner3.Scan()
+	go4 := scanner4.Scan()
 	var next string
+	if go3 != go4 {
+		t.Error("One file has more lines")
+	}
 	for go3 {
+		if scanner3.Text() != scanner4.Text() {
+			t.Error("Content is different at line level", scanner3.Text(), scanner4.Text())
+		}
 		next = scanner3.Text()
 		go3 = scanner3.Scan()
+		go4 = scanner4.Scan()
+		if go3 != go4 {
+			t.Error("One file has more lines")
+		}
 	}
 
 	decodedSection := decode(t, []byte(next))[0]

--- a/internal/pkg/zonefile/zoneFileIO_test.go
+++ b/internal/pkg/zonefile/zoneFileIO_test.go
@@ -3,7 +3,9 @@ package zonefile
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io/ioutil"
+	"strings"
 	"testing"
 
 	"github.com/netsec-ethz/rains/internal/pkg/section"
@@ -40,4 +42,29 @@ func TestEncodeDecodeZone(t *testing.T) {
 			t.Error("One file has more content")
 		}
 	}
+
+	// Check reencoding single assertions works
+	scanner3 := bufio.NewScanner(bytes.NewReader(origData))
+	scanner3.Split(bufio.ScanLines)
+	go3 := scanner3.Scan()
+	var next string
+	for go3 {
+		next = scanner3.Text()
+		go3 = scanner3.Scan()
+	}
+
+	decodedSection := decode(t, []byte(next))[0]
+	stringSection := strings.TrimSpace(IO{}.Encode([]section.Section{decodedSection}))
+	if next != stringSection {
+		t.Error(fmt.Sprintf("Content is different:\nExpected:\t'%v'\nGot:\t\t'%v'", next, stringSection))
+	}
+}
+
+func decode(t *testing.T, input []byte) []section.WithSigForward {
+        zfParser := IO{}
+        sections, err := zfParser.Decode(input)
+        if err != nil {
+                t.Error(fmt.Sprintf("Was not able to parse section: %v", err))
+        }
+        return sections
 }


### PR DESCRIPTION
Before:
```
:A: umbrail node.snet. . [ :scionip4:17-ffaa:1:133,[192.33.93.144] ] ( :sig: :ed25519: :rains: 0 1552291915 1552335115 5e6c155cd9dd5a2d6937fa4cfa97884a298167b12cd8cb9eacf01cc9d8ad769cad0a2ae7e811b0845877e343a9be72307db291a041b01c120fec7f24e76e5f02 )
```

After:
```
:A: umbrail node.snet. . [ :scionip4:  17-ffaa:1:133,[192.33.93.144] ] ( :sig: :ed25519: :rains: 0 1552291915 1552335115 5e6c155cd9dd5a2d6937fa4cfa97884a298167b12cd8cb9eacf01cc9d8ad769cad0a2ae7e811b0845877e343a9be72307db291a041b01c120fec7f24e76e5f02 )
```

`:scionip4:` and `:scionip6:` have len 10,  the previous max indent length was <pre>"          "</pre>, resulting in the output not being properly delimited.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/rains/220)
<!-- Reviewable:end -->
