### PR TITLE
Update to scion master, adapt to changed API

### DIFF
--- a/cmd/rainsd/rainsd.go
+++ b/cmd/rainsd/rainsd.go
@@ -362,7 +362,7 @@ func (i *addressFlag) Set(value string) (err error) {
 	i.value = connection.Info{}
 	i.value.Addr, err = net.ResolveTCPAddr("", value)
 	if err != nil { // Not an IP address
-		i.value.Addr, err = snet.UDPAddrFromString(value)
+		i.value.Addr, err = snet.ParseUDPAddr(value)
 		if err == nil {
 			i.value.Type = connection.SCION
 		}

--- a/cmd/rdig/rdig.go
+++ b/cmd/rdig/rdig.go
@@ -76,7 +76,7 @@ func main() {
 	}
 
 	var serverAddr net.Addr
-	serverAddr, err := snet.UDPAddrFromString(fmt.Sprintf("%s:%d", server, *port))
+	serverAddr, err := snet.ParseUDPAddr(fmt.Sprintf("%s:%d", server, *port))
 	if err != nil {
 		// was not a valid SCION address, try to parse it as a regular IP address
 		serverAddr, err = net.ResolveTCPAddr("", fmt.Sprintf("%s:%d", server, *port))

--- a/cmd/zonepub/zonepub.go
+++ b/cmd/zonepub/zonepub.go
@@ -281,7 +281,7 @@ func (i *addressesFlag) Set(value string) error {
 		if tcpAddr, err := net.ResolveTCPAddr("tcp", addr); err == nil {
 			i.value = append(i.value, connection.Info{Type: connection.TCP, Addr: tcpAddr})
 		} else {
-			if scionAddr, err := snet.UDPAddrFromString(value); err == nil {
+			if scionAddr, err := snet.ParseUDPAddr(value); err == nil {
 				i.value = append(i.value, connection.Info{Type: connection.SCION, Addr: scionAddr})
 			} else {
 				return err

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/britram/borat v0.0.0-20181011130314-f891bcfcfb9b
 	github.com/d4l3k/messagediff v1.2.1 // indirect
 	github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec
-	github.com/scionproto/scion v0.4.1-0.20200302170049-bf51fb3769f5
+	github.com/scionproto/scion v0.4.1-0.20200324160848-64e5ff95eec1
 	github.com/spf13/cobra v0.0.4-0.20190109003409-7547e83b2d85
 	github.com/spf13/pflag v1.0.4-0.20181223182923-24fa6976df40
 	golang.org/x/crypto v0.0.0-20190909091759-094676da4a83

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.3 h1:CTwfnzjQ+8dS6MhHHu4YswVAD99sL2wjPqP+VkURmKE=
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
-github.com/scionproto/scion v0.4.1-0.20200302170049-bf51fb3769f5 h1:aVX6gM9dRRS3i0Qhpdf1tT86DBTAmr7glR3aRg8He1c=
-github.com/scionproto/scion v0.4.1-0.20200302170049-bf51fb3769f5/go.mod h1:yayLUQzSt/Lwg+3dA2terZ3tEgXI9r7CX8MKrX5CIdI=
+github.com/scionproto/scion v0.4.1-0.20200324160848-64e5ff95eec1 h1:dEWLk21ts5TMiIpiPql0+G5j+IwyqSu/0W2sY29XoAk=
+github.com/scionproto/scion v0.4.1-0.20200324160848-64e5ff95eec1/go.mod h1:yayLUQzSt/Lwg+3dA2terZ3tEgXI9r7CX8MKrX5CIdI=
 github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=

--- a/internal/pkg/connection/connection.go
+++ b/internal/pkg/connection/connection.go
@@ -66,7 +66,7 @@ func UnmarshalNetAddr(data []byte) (Type, net.Addr, error) {
 		if !ok {
 			return -1, nil, errors.New("local address must be a string")
 		}
-		scionLocal, err := snet.UDPAddrFromString(local)
+		scionLocal, err := snet.ParseUDPAddr(local)
 		if err != nil {
 			return -1, nil, fmt.Errorf("failed to parse local addr: %v", err)
 		}

--- a/internal/pkg/connection/scion/appnet.go
+++ b/internal/pkg/connection/scion/appnet.go
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 /*
-Package connection/scion provides a simplified and functionally extended
-wrapper interface to the scionproto/scion package snet.
+Package connection/scion provides a simplified and functionally extended wrapper interface to the
+scionproto/scion package snet.
 
 NOTE: this is identical with github.com/netsec-ethz/scion-apps/pkg/appnet, with some omissions
 
@@ -28,10 +28,10 @@ be overridden using environment variables:
 		SCION_DISPATCHER_SOCKET: /run/shm/dispatcher/default.sock
 		SCION_DAEMON_ADDRESS: 127.0.0.1:30255
 
-This is convenient for the normal use case of running a the endhost stack for
-a single SCION AS. When running multiple local ASes, e.g. during development, the path
-to the sciond corresponding to the desired AS needs to be specified in the
-SCION_DAEMON_ADDRESS environment variable.
+This is convenient for the normal use case of running a the endhost stack for a
+single SCION AS. When running multiple local ASes, e.g. during development, the
+address of the sciond corresponding to the desired AS needs to be specified in
+the SCION_DAEMON_ADDRESS environment variable.
 
 
 Wildcard IP Addresses

--- a/internal/pkg/connection/scion/appnet.go
+++ b/internal/pkg/connection/scion/appnet.go
@@ -56,10 +56,12 @@ import (
 	"net"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/snet/addrutil"
 	"github.com/scionproto/scion/go/lib/sock/reliable"
 )
 
@@ -73,6 +75,10 @@ type Network struct {
 	PathQuerier   snet.PathQuerier
 	hostInLocalAS net.IP
 }
+
+const (
+	initTimeout = 1 * time.Second
+)
 
 var defNetwork Network
 var initOnce sync.Once
@@ -96,15 +102,19 @@ func DefNetwork() *Network {
 // support long lived connections well, as the path *will* expire.
 // This is all that snet currently provides, we'll need to add a layer on top
 // that updates the paths in case they expire or are revoked.
-func DialAddr(raddr *snet.UDPAddr) (snet.Conn, error) {
+func DialAddr(raddr *snet.UDPAddr) (*snet.Conn, error) {
 	if raddr.Path == nil {
 		err := SetDefaultPath(raddr)
 		if err != nil {
 			return nil, err
 		}
 	}
-	laddr := &net.UDPAddr{IP: localIP(raddr)}
-	return DefNetwork().Dial(context.TODO(), "udp", laddr, raddr, addr.SvcNone)
+	localIP, err := resolveLocal(raddr)
+	if err != nil {
+		return nil, err
+	}
+	laddr := &net.UDPAddr{IP: localIP}
+	return DefNetwork().Dial(context.Background(), "udp", laddr, raddr, addr.SvcNone)
 }
 
 // Listen acts like net.ListenUDP in a SCION network.
@@ -112,35 +122,38 @@ func DialAddr(raddr *snet.UDPAddr) (snet.Conn, error) {
 // listen on a wildcard address.
 //
 // See note on wildcard addresses in the package documentation.
-func Listen(listen *net.UDPAddr) (snet.Conn, error) {
+func Listen(listen *net.UDPAddr) (*snet.Conn, error) {
 	if listen == nil {
 		listen = &net.UDPAddr{}
 	}
 	if listen.IP == nil || listen.IP.IsUnspecified() {
-		listen = &net.UDPAddr{IP: defaultLocalIP(), Port: listen.Port, Zone: listen.Zone}
+		localIP, err := defaultLocalIP()
+		if err != nil {
+			return nil, err
+		}
+		listen = &net.UDPAddr{IP: localIP, Port: listen.Port, Zone: listen.Zone}
 	}
-	return DefNetwork().Listen(context.TODO(), "udp", listen, addr.SvcNone)
+	return DefNetwork().Listen(context.Background(), "udp", listen, addr.SvcNone)
 }
 
 // ListenPort is a shortcut to Listen on a specific port with a wildcard IP address.
 //
 // See note on wildcard addresses in the package documentation.
-func ListenPort(port uint16) (snet.Conn, error) {
-	listen := &net.UDPAddr{IP: defaultLocalIP(), Port: int(port)}
-	return DefNetwork().Listen(context.TODO(), "udp", listen, addr.SvcNone)
+func ListenPort(port uint16) (*snet.Conn, error) {
+	return Listen(&net.UDPAddr{Port: int(port)})
 }
 
-// localAddr returns the source IP address for traffic to raddr. If
+// resolveLocal returns the source IP address for traffic to raddr. If
 // raddr.NextHop is set, it's used to determine the local IP address.
 // Otherwise, the default local IP address is returned.
 //
 // The purpose of this function is to workaround not being able to bind to
 // wildcard addresses in snet.
 // See note on wildcard addresses in the package documentation.
-func localIP(raddr *snet.UDPAddr) net.IP {
+func resolveLocal(raddr *snet.UDPAddr) (net.IP, error) {
 	if raddr.NextHop != nil {
 		nextHop := raddr.NextHop.IP
-		return findSrcIP(nextHop)
+		return addrutil.ResolveLocal(nextHop)
 	}
 	return defaultLocalIP()
 }
@@ -150,8 +163,8 @@ func localIP(raddr *snet.UDPAddr) net.IP {
 // The purpose of this function is to workaround not being able to bind to
 // wildcard addresses in snet.
 // See note on wildcard addresses in the package documentation.
-func defaultLocalIP() net.IP {
-	return findSrcIP(DefNetwork().hostInLocalAS)
+func defaultLocalIP() (net.IP, error) {
+	return addrutil.ResolveLocal(DefNetwork().hostInLocalAS)
 }
 
 func mustInitDefNetwork() {
@@ -163,19 +176,21 @@ func mustInitDefNetwork() {
 }
 
 func initDefNetwork() error {
+	ctx, cancel := context.WithTimeout(context.Background(), initTimeout)
+	defer cancel()
 	dispatcher, err := findDispatcher()
 	if err != nil {
 		return err
 	}
-	sciondConn, err := findSciond()
+	sciondConn, err := findSciond(ctx)
 	if err != nil {
 		return err
 	}
-	localIA, err := findLocalIA(sciondConn)
+	localIA, err := sciondConn.LocalIA(ctx)
 	if err != nil {
 		return err
 	}
-	hostInLocalAS, err := findAnyHostInLocalAS(sciondConn)
+	hostInLocalAS, err := findAnyHostInLocalAS(ctx, sciondConn)
 	if err != nil {
 		return err
 	}
@@ -190,12 +205,12 @@ func initDefNetwork() error {
 	return nil
 }
 
-func findSciond() (sciond.Connector, error) {
+func findSciond(ctx context.Context) (sciond.Connector, error) {
 	address, ok := os.LookupEnv("SCION_DAEMON_ADDRESS")
 	if !ok {
 		address = sciond.DefaultSCIONDAddress
 	}
-	sciondConn, err := sciond.NewService(address).Connect(context.Background())
+	sciondConn, err := sciond.NewService(address).Connect(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to SCIOND at %s (override with SCION_DAEMON_ADDRESS): %w", address, err)
 	}
@@ -238,28 +253,9 @@ func isSocket(mode os.FileMode) bool {
 	return mode&os.ModeSocket != 0
 }
 
-func findLocalIA(sciondConn sciond.Connector) (addr.IA, error) {
-	asInfo, err := sciondConn.ASInfo(context.TODO(), addr.IA{})
-	if err != nil {
-		return addr.IA{}, err
-	}
-	ia := asInfo.Entries[0].RawIsdas.IA()
-	return ia, nil
-}
-
-// findSrcIP returns the src IP used for traffic destined to dst
-func findSrcIP(dst net.IP) net.IP {
-	// Use net.Dial to lookup source address. Alternatively, could use netlink.
-	udpAddr := net.UDPAddr{IP: dst, Port: 1}
-	udpConn, _ := net.DialUDP(udpAddr.Network(), nil, &udpAddr)
-	srcIP := udpConn.LocalAddr().(*net.UDPAddr).IP
-	udpConn.Close()
-	return srcIP
-}
-
 // findAnyHostInLocalAS returns the IP address of some (infrastructure) host in the local AS.
-func findAnyHostInLocalAS(sciondConn sciond.Connector) (net.IP, error) {
-	addr, err := sciond.TopoQuerier{Connector: sciondConn}.OverlayAnycast(context.Background(), addr.SvcBS)
+func findAnyHostInLocalAS(ctx context.Context, sciondConn sciond.Connector) (net.IP, error) {
+	addr, err := sciond.TopoQuerier{Connector: sciondConn}.OverlayAnycast(ctx, addr.SvcBS)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/libresolve/resolver.go
+++ b/internal/pkg/libresolve/resolver.go
@@ -381,7 +381,7 @@ func (r *Resolver) handleRedirect(name string, srvMap map[string]object.ServiceI
 			var tcpErr error
 			addr, tcpErr = net.ResolveTCPAddr("", fmt.Sprintf("%s:%d", ipAddr, rainsPort))
 			if tcpErr != nil {
-				addr, err = snet.UDPAddrFromString(fmt.Sprintf("%s:%d", ipAddr, rainsPort))
+				addr, err = snet.ParseUDPAddr(fmt.Sprintf("%s:%d", ipAddr, rainsPort))
 				if err != nil {
 					log.Error("Not an IP addr nor a SCION addr at handleRedirect OTXAddrX", "addr", addr, "tcpErr", tcpErr, "scionErr", err)
 				}
@@ -399,7 +399,7 @@ func (r *Resolver) handleRedirect(name string, srvMap map[string]object.ServiceI
 				ip := addr.String()[:portSep]
 				addr, tcpErr = net.ResolveTCPAddr("", fmt.Sprintf("%s:%d", ip, srvVal.Port))
 				if tcpErr != nil {
-					addr, err = snet.UDPAddrFromString(fmt.Sprintf("%s:%d", ip, srvVal.Port))
+					addr, err = snet.ParseUDPAddr(fmt.Sprintf("%s:%d", ip, srvVal.Port))
 					if err != nil {
 						log.Error("Not and IP addr nor a SCION addr at handleRedirect OTXAddrX", "addr", addr, "tcpErr", tcpErr, "scionErr", err)
 					}

--- a/internal/pkg/object/object.go
+++ b/internal/pkg/object/object.go
@@ -33,7 +33,7 @@ func (sa *SCIONAddress) String() string {
 }
 
 func ParseSCIONAddress(address string) (*SCIONAddress, error) {
-	addr, err := snet.UDPAddrFromString(address)
+	addr, err := snet.ParseUDPAddr(address)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adapt use of `snet.Conn` type (no longer an interface, but a struct).
Adapt use of renamed `UDPAddrFromString`, now `ParseUDPAddr`.

Use some new helper functions added in scion (`sciondConn.LocalIA` and `snet/addrutil.ResolveLocal`).

Misc cleanup; handle previously ignored error for finding local IP, add timeout to sciond connection and queries during initialization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/rains/235)
<!-- Reviewable:end -->
